### PR TITLE
Update package.yaml

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -15,6 +15,9 @@ maintainer:     Freckle Education
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
 
 source-repository head
   type: git

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -76,7 +76,7 @@ library
     , MonadRandom
     , aeson
     , ansi-terminal
-    , base
+    , base <5
     , bytestring
     , case-insensitive
     , conduit
@@ -158,7 +158,7 @@ test-suite doctest
       TypeApplications
       TypeFamilies
   build-depends:
-      base
+      base <5
     , freckle-app
   default-language: Haskell2010
 
@@ -202,7 +202,7 @@ test-suite spec
   ghc-options: -threaded -rtsopts -O0 "-with-rtsopts=-N"
   build-depends:
       aeson
-    , base
+    , base <5
     , bytestring
     , directory
     , freckle-app

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -199,7 +199,7 @@ test-suite spec
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -threaded -rtsopts -O0 "-with-rtsopts=-N"
+  ghc-options: -threaded -rtsopts "-with-rtsopts=-N"
   build-depends:
       aeson
     , base <5

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -6,9 +6,19 @@ cabal-version: 1.12
 
 name:           freckle-app
 version:        1.0.0.0
+synopsis:       Haskell application toolkit used at Freckle
+description:    Please see README.md
+category:       Utils
+homepage:       https://github.com/freckle/freckle-app#readme
+bug-reports:    https://github.com/freckle/freckle-app/issues
+maintainer:     Freckle Education
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/freckle/freckle-app
 
 library
   exposed-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -94,7 +94,7 @@ tests:
   spec:
     main: Main.hs
     source-dirs: tests
-    ghc-options: -threaded -rtsopts -O0 "-with-rtsopts=-N"
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N"
     dependencies:
       - aeson
       - bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,11 @@
 ---
 name: freckle-app
 version: 1.0.0.0
+maintainer: Freckle Education
+category: Utils
+github: freckle/freckle-app
+synopsis: Haskell application toolkit used at Freckle
+description: Please see README.md
 
 dependencies:
   - base

--- a/package.yaml
+++ b/package.yaml
@@ -8,8 +8,8 @@ synopsis: Haskell application toolkit used at Freckle
 description: Please see README.md
 
 extra-source-files:
-- README.md
-- CHANGELOG.md
+  - README.md
+  - CHANGELOG.md
 
 dependencies:
   - base < 5

--- a/package.yaml
+++ b/package.yaml
@@ -7,6 +7,10 @@ github: freckle/freckle-app
 synopsis: Haskell application toolkit used at Freckle
 description: Please see README.md
 
+extra-source-files:
+- README.md
+- CHANGELOG.md
+
 dependencies:
   - base < 5
 

--- a/package.yaml
+++ b/package.yaml
@@ -8,7 +8,7 @@ synopsis: Haskell application toolkit used at Freckle
 description: Please see README.md
 
 dependencies:
-  - base
+  - base < 5
 
 default-extensions:
   - BangPatterns


### PR DESCRIPTION
Three separate updates are made here:

1. Add meta-data to package.yaml, such as description, maintainer, etc.
2. Add an upper bound on the `base` package.
3. Get rid of the `-o0` flag in the test suite. Apparently, this the [default](url) for ghc 8.10.4 so removal should be safe here.

All changes are in the service of getting our `release` GitHub Action to complete. 