### PR TITLE
Ensure that `Release` GitHub Action completes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v1.0.0.1](https://github.com/freckle/freckle-app/compare/v1.0.0.0...v1.0.0.1)
+
+- Ensure `release` GitHub Action completes properly.
+
 ## [v1.0.0.0](https://github.com/freckle/freckle-app/tree/v1.0.0.0)
 
 First tagged release.

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.0.0.0
+version: 1.0.0.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
Ensure that `Release` GitHub Action completes. Note that this has no code changes, and thus uses the "additional component" in [Haskell PVP](https://pvp.haskell.org/), which states:

"A package version number SHOULD have the form A.B.C, and MAY optionally have any number of additional components, for example 2.1.0.4 (in this case, A=2, B=1, C=0). This policy defines the meaning of the first three components A-C, the other components can be used in any way the package maintainer sees fit"