### PR TITLE
Add `package.yaml` to `extra-source-files`.

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -18,6 +18,7 @@ build-type:     Simple
 extra-source-files:
     README.md
     CHANGELOG.md
+    package.yaml
 
 source-repository head
   type: git

--- a/package.yaml
+++ b/package.yaml
@@ -10,6 +10,7 @@ description: Please see README.md
 extra-source-files:
   - README.md
   - CHANGELOG.md
+  - package.yaml
 
 flags:
   test-git:


### PR DESCRIPTION
This will include `package.yaml` in the tarball that is uploaded to
hackage. See
[comment](https://github.com/commercialhaskell/stackage/issues/6172#issuecomment-907842852).