### PR TITLE
Add function for responding 503 on query-cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   interface is backwards-compatible. By normal Haskell rules, it would be major
   since it's changing the type of something exported.
 
+- Add `catchQueryCanceled` Yesod Middlewares
+
 ## [v1.0.0.3](https://github.com/freckle/freckle-app/compare/v1.0.0.2...v1.0.0.3)
 
 - Add `package.yaml` to `extra-source-files`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   interface is backwards-compatible. By normal Haskell rules, it would be major
   since it's changing the type of something exported.
 
-- Add `catchQueryCanceled` Yesod Middlewares
+- Add `handleQueryCanceled` Yesod Middlewares
 
 ## [v1.0.0.3](https://github.com/freckle/freckle-app/compare/v1.0.0.2...v1.0.0.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   interface is backwards-compatible. By normal Haskell rules, it would be major
   since it's changing the type of something exported.
 
-- Add `handleQueryCanceled` Yesod Middlewares
+- Add `respondQueryCanceled` Yesod Middlewares
 
 ## [v1.0.0.3](https://github.com/freckle/freckle-app/compare/v1.0.0.2...v1.0.0.3)
 

--- a/library/Freckle/App/Yesod.hs
+++ b/library/Freckle/App/Yesod.hs
@@ -2,15 +2,24 @@
 module Freckle.App.Yesod
   ( makeLogger
   , messageLoggerSource
-  )
-where
+
+  -- * Functions for use as 'yesodMiddleware'
+  , catchQueryCanceled
+  , catchQueryCanceledHeaders
+  ) where
 
 import Prelude
 
-import Control.Monad (when)
+import Control.Monad (guard, when)
 import Control.Monad.Logger
+import Data.Text (pack)
+import Database.PostgreSQL.Simple (SqlError(..))
+import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags)
+import qualified Freckle.App.Datadog as Datadog
 import Freckle.App.GlobalCache
 import Freckle.App.Logging
+import Network.HTTP.Types (ResponseHeaders, status503)
+import qualified Network.Wai as W
 import System.IO.Unsafe (unsafePerformIO)
 import System.Log.FastLogger
   ( LoggerSet
@@ -19,7 +28,9 @@ import System.Log.FastLogger
   , newStderrLoggerSet
   , newStdoutLoggerSet
   )
-import Yesod.Core.Types (Logger, loggerPutStr)
+import UnliftIO.Exception (handleJust)
+import Yesod.Core.Handler (sendWaiResponse)
+import Yesod.Core.Types (HandlerFor, Logger, loggerPutStr)
 import Yesod.Default.Config2 (makeYesodLogger)
 
 loggerSetVar :: GlobalCache LoggerSet
@@ -53,3 +64,27 @@ messageLoggerSource app logger loc src level str =
         FormatJSON -> formatJsonLogStr loc src level str
         FormatTerminal ->
           formatTerminal (getLogDefaultANSI app) loc src level str
+
+-- | Catch 'SqlError' for when queries are canceled due to timeout
+--
+-- Logs, increments a metric, and responds with 503.
+--
+catchQueryCanceled
+  :: (HasDogStatsClient site, HasDogStatsTags site)
+  => HandlerFor site res
+  -> HandlerFor site res
+catchQueryCanceled = catchQueryCanceledHeaders []
+
+-- | 'catchQueryCanceledHeaders' but adding headers to the 503 response
+catchQueryCanceledHeaders
+  :: (HasDogStatsClient site, HasDogStatsTags site)
+  => ResponseHeaders
+  -> HandlerFor site res
+  -> HandlerFor site res
+catchQueryCanceledHeaders headers = handleJust queryCanceled $ \ex -> do
+  logErrorN $ pack $ show ex
+  Datadog.increment "query_canceled" []
+  sendWaiResponse $ W.responseLBS status503 headers "Query canceled"
+
+queryCanceled :: SqlError -> Maybe SqlError
+queryCanceled ex = ex <$ guard (sqlState ex == "57014")

--- a/library/Freckle/App/Yesod.hs
+++ b/library/Freckle/App/Yesod.hs
@@ -4,8 +4,8 @@ module Freckle.App.Yesod
   , messageLoggerSource
 
   -- * Functions for use as 'yesodMiddleware'
-  , catchQueryCanceled
-  , catchQueryCanceledHeaders
+  , handleQueryCanceled
+  , handleQueryCanceledHeaders
   ) where
 
 import Prelude
@@ -69,19 +69,19 @@ messageLoggerSource app logger loc src level str =
 --
 -- Logs, increments a metric, and responds with 503.
 --
-catchQueryCanceled
+handleQueryCanceled
   :: (HasDogStatsClient site, HasDogStatsTags site)
   => HandlerFor site res
   -> HandlerFor site res
-catchQueryCanceled = catchQueryCanceledHeaders []
+handleQueryCanceled = handleQueryCanceledHeaders []
 
--- | 'catchQueryCanceledHeaders' but adding headers to the 503 response
-catchQueryCanceledHeaders
+-- | 'handleQueryCanceledHeaders' but adding headers to the 503 response
+handleQueryCanceledHeaders
   :: (HasDogStatsClient site, HasDogStatsTags site)
   => ResponseHeaders
   -> HandlerFor site res
   -> HandlerFor site res
-catchQueryCanceledHeaders headers = handleJust queryCanceled $ \ex -> do
+handleQueryCanceledHeaders headers = handleJust queryCanceled $ \ex -> do
   logErrorN $ pack $ show ex
   Datadog.increment "query_canceled" []
   sendWaiResponse $ W.responseLBS status503 headers "Query canceled"


### PR DESCRIPTION
When the `statement_timeout` set by `Freckle.App.Database` triggers, we get this
`SqlError`. By attaching one of these functions as `yesodMiddleware`, we can
turn that into a 503.

The function also logs, increments a DogStats metric, and supports attaching
headers (necessary for our AuthorizationChecked machinery).