### PR TITLE
Add Request Metrics Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Add `respondQueryCanceled` Yesod Middlewares
 
+- Add `makeRequestMetricsMiddleware`
+
 ## [v1.0.0.3](https://github.com/freckle/freckle-app/compare/v1.0.0.2...v1.0.0.3)
 
 - Add `package.yaml` to `extra-source-files`.

--- a/library/Freckle/App/Wai.hs
+++ b/library/Freckle/App/Wai.hs
@@ -184,7 +184,6 @@ makeRequestMetricsMiddleware env getRouteName app req sendResponse' = do
          , ("status", pack $ show $ statusCode $ responseStatus res)
          ]
 
-
 noCacheMiddleware :: Middleware
 noCacheMiddleware = addHeaders [cacheControlHeader]
  where


### PR DESCRIPTION
Increments generic metrics, expecting that the environment will use tags to
disambiguate (e.g. app:fancy-api).