### PR TITLE
Enable reporting RTS stats to datadog

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -43,6 +43,7 @@ library
       Freckle.App.Http.Retry
       Freckle.App.Logging
       Freckle.App.RIO
+      Freckle.App.RtsStats
       Freckle.App.Test
       Freckle.App.Test.DocTest
       Freckle.App.Test.Hspec.Runner
@@ -91,6 +92,7 @@ library
     , data-default
     , datadog
     , doctest
+    , ekg-core
     , errors
     , exceptions
     , fast-logger
@@ -126,6 +128,7 @@ library
     , transformers-base
     , unliftio
     , unliftio-core
+    , unordered-containers
     , wai
     , wai-extra
     , yaml

--- a/library/Freckle/App/RtsStats.hs
+++ b/library/Freckle/App/RtsStats.hs
@@ -1,0 +1,61 @@
+-- | RTS statistics sent to Datadog
+module Freckle.App.RtsStats
+  ( forkRtsStatPolling
+  ) where
+
+import Prelude
+
+import Control.Monad (forever, void)
+import Control.Monad.IO.Unlift (MonadUnliftIO, liftIO)
+import Control.Monad.Reader (MonadReader)
+import Data.Foldable (traverse_)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Text (Text)
+import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags)
+import qualified Freckle.App.Datadog as Datadog
+import qualified System.Metrics as Ekg
+import qualified System.Metrics.Distribution.Internal as Ekg
+import UnliftIO.Concurrent (forkIO, threadDelay)
+
+-- | Initialize a thread to poll RTS stats
+--
+-- Stats are collected via `ekg-core` and 'System.Metrics.registerGcMetrics'
+--
+forkRtsStatPolling
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => m ()
+forkRtsStatPolling = do
+  store <- liftIO Ekg.newStore
+  liftIO $ Ekg.registerGcMetrics store
+
+  void $ forkIO $ forever $ do
+    sample <- liftIO $ Ekg.sampleAll store
+    traverse_ (uncurry flushEkgSample) $ HashMap.toList sample
+
+    let seconds n = n * 1000000
+    threadDelay $ seconds 1
+
+flushEkgSample
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => Text
+  -> Ekg.Value
+  -> m ()
+flushEkgSample name = \case
+  Ekg.Counter n -> Datadog.counter name [] $ fromIntegral n
+  Ekg.Gauge n -> Datadog.guage name [] $ fromIntegral n
+  Ekg.Distribution d -> do
+    Datadog.guage (name <> "." <> "mean") [] $ Ekg.mean d
+    Datadog.guage (name <> "." <> "variance") [] $ Ekg.variance d
+    Datadog.guage (name <> "." <> "sum") [] $ Ekg.sum d
+    Datadog.guage (name <> "." <> "min") [] $ Ekg.min d
+    Datadog.guage (name <> "." <> "max") [] $ Ekg.max d
+    Datadog.counter (name <> "." <> "count") [] $ fromIntegral $ Ekg.count d
+  Ekg.Label _ -> pure ()

--- a/package.yaml
+++ b/package.yaml
@@ -60,6 +60,7 @@ library:
     - data-default
     - datadog
     - doctest
+    - ekg-core
     - errors
     - exceptions
     - fast-logger
@@ -95,6 +96,7 @@ library:
     - transformers-base
     - unliftio
     - unliftio-core
+    - unordered-containers
     - wai
     - wai-extra
     - yaml


### PR DESCRIPTION
This capability existed as a one off within a single service. This
information can be useful to determine whether RTS behavior is leading
to CPU or memory issues and is simple to abstract.

This leans on `ekg-core` to collect the stats about the RTS. It then
initializes a loop to poll that information and send it to DataDog.