### PR TITLE
Encapsulate EKG gauges

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -34,6 +34,7 @@ library
       Freckle.App
       Freckle.App.Database
       Freckle.App.Datadog
+      Freckle.App.Datadog.Gauge
       Freckle.App.Env
       Freckle.App.Env.Internal
       Freckle.App.Ghci

--- a/library/Freckle/App/Datadog.hs
+++ b/library/Freckle/App/Datadog.hs
@@ -21,14 +21,6 @@ module Freckle.App.Datadog
   , histogramSince
   , histogramSinceMs
 
-  -- ** Stateful Gauges
-  , Gauge
-  , newGauge
-  , incrementGauge
-  , decrementGauge
-  , addGauge
-  , subtractGauge
-
   -- * Reading settings at startup
   , DogStatsSettings(..)
   , envParseDogStatsEnabled
@@ -43,13 +35,11 @@ import Control.Lens (set)
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Reader
 import Data.Foldable (for_)
-import Data.Int (Int64)
 import Data.Text (Text)
 import Data.Time (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
 import qualified Freckle.App.Env as Env
-import Network.StatsD.Datadog hiding (Gauge, metric, name, tags)
+import Network.StatsD.Datadog hiding (metric, name, tags)
 import qualified Network.StatsD.Datadog as Datadog
-import qualified System.Metrics.Gauge as EKG
 import Yesod.Core.Types (HandlerData, handlerEnv, rheSite)
 
 class HasDogStatsClient app where
@@ -85,84 +75,8 @@ counter
   -> [(Text, Text)]
   -> Int
   -> m ()
-counter name tags = sendAppMetricWithTags name tags Datadog.Counter
+counter name tags = sendAppMetricWithTags name tags Counter
 
--- | A data type containing all reporting values for a gauge
-data Gauge = Gauge
-  { gaugeName :: Text
-  , gaugeTags :: [(Text, Text)]
-  , gaugeAtomic :: EKG.Gauge
-  }
-
--- | Create a gauge holding in memory state
-newGauge :: (MonadIO m) => Text -> [(Text, Text)] -> m Gauge
-newGauge name tags = Gauge name tags <$> liftIO EKG.new
-
--- | Increment gauge state and report its current value
-incrementGauge
-  :: ( MonadUnliftIO m
-     , MonadReader env m
-     , HasDogStatsClient env
-     , HasDogStatsTags env
-     )
-  => Gauge
-  -> m ()
-incrementGauge = addGauge 1
-
--- | Add to gauge state and report its current value
-addGauge
-  :: ( MonadUnliftIO m
-     , MonadReader env m
-     , HasDogStatsClient env
-     , HasDogStatsTags env
-     )
-  => Int64
-  -> Gauge
-  -> m ()
-addGauge i = withGauge (`EKG.add` i)
-
--- | Decrement gauge state and report its current value
-decrementGauge
-  :: ( MonadUnliftIO m
-     , MonadReader env m
-     , HasDogStatsClient env
-     , HasDogStatsTags env
-     )
-  => Gauge
-  -> m ()
-decrementGauge = subtractGauge 1
-
--- | Subtract from gauge state and report its current value
-subtractGauge
-  :: ( MonadUnliftIO m
-     , MonadReader env m
-     , HasDogStatsClient env
-     , HasDogStatsTags env
-     )
-  => Int64
-  -> Gauge
-  -> m ()
-subtractGauge i = withGauge (`EKG.subtract` i)
-
-withGauge
-  :: ( MonadUnliftIO m
-     , MonadReader env m
-     , HasDogStatsClient env
-     , HasDogStatsTags env
-     )
-  => (EKG.Gauge -> IO ())
-  -> Gauge
-  -> m ()
-withGauge f Gauge {..} = do
-  current <- liftIO $ do
-    f gaugeAtomic
-    EKG.read gaugeAtomic
-  gauge gaugeName gaugeTags $ fromIntegral current
-
--- | Report the state of a gauge directly
---
--- This can be used by gauges where state is derived from other means.
---
 gauge
   :: ( MonadUnliftIO m
      , MonadReader env m
@@ -173,7 +87,7 @@ gauge
   -> [(Text, Text)]
   -> Double
   -> m ()
-gauge name tags = sendAppMetricWithTags name tags Datadog.Gauge
+gauge name tags = sendAppMetricWithTags name tags Gauge
 
 histogram
   :: ( MonadUnliftIO m
@@ -187,7 +101,7 @@ histogram
   -> n
   -> m ()
 histogram name tags metricValue =
-  sendAppMetricWithTags name tags Datadog.Histogram metricValue
+  sendAppMetricWithTags name tags Histogram metricValue
 
 histogramSince
   :: ( MonadUnliftIO m
@@ -234,7 +148,7 @@ histogramSinceBy
 histogramSinceBy f name tags time = do
   now <- liftIO getCurrentTime
   let delta = f $ now `diffUTCTime` time
-  sendAppMetricWithTags name tags Datadog.Histogram delta
+  sendAppMetricWithTags name tags Histogram delta
 
 sendAppMetricWithTags
   :: ( MonadUnliftIO m

--- a/library/Freckle/App/Datadog.hs
+++ b/library/Freckle/App/Datadog.hs
@@ -92,6 +92,7 @@ gauge
   -> m ()
 gauge name tags = sendAppMetricWithTags name tags Gauge
 
+{-# DEPRECATED guage "Use gauge instead" #-}
 -- | Deprecated typo version of 'gauge'
 guage
   :: ( MonadUnliftIO m

--- a/library/Freckle/App/Datadog.hs
+++ b/library/Freckle/App/Datadog.hs
@@ -27,6 +27,9 @@ module Freckle.App.Datadog
   , envParseDogStatsSettings
   , envParseDogStatsTags
   , mkStatsClient
+
+  -- * To be removed in next major bump
+  , guage
   ) where
 
 import Prelude
@@ -88,6 +91,19 @@ gauge
   -> Double
   -> m ()
 gauge name tags = sendAppMetricWithTags name tags Gauge
+
+-- | Deprecated typo version of 'gauge'
+guage
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => Text
+  -> [(Text, Text)]
+  -> Double
+  -> m ()
+guage = gauge
 
 histogram
   :: ( MonadUnliftIO m

--- a/library/Freckle/App/Datadog/Gauge.hs
+++ b/library/Freckle/App/Datadog/Gauge.hs
@@ -21,7 +21,7 @@ import qualified System.Metrics.Gauge as EKG
 data Gauge = Gauge
   { name :: Text
   , tags :: [(Text, Text)]
-  , atomic :: EKG.Gauge
+  , ekgGauge :: EKG.Gauge
   }
 
 -- | Create a gauge holding in memory state
@@ -49,7 +49,7 @@ add
   => Int64
   -> Gauge
   -> m ()
-add i = withGauge (`EKG.add` i)
+add i = withEKGGauge (`EKG.add` i)
 
 -- | Decrement gauge state and report its current value
 decrement
@@ -72,9 +72,9 @@ subtract
   => Int64
   -> Gauge
   -> m ()
-subtract i = withGauge (`EKG.subtract` i)
+subtract i = withEKGGauge (`EKG.subtract` i)
 
-withGauge
+withEKGGauge
   :: ( MonadUnliftIO m
      , MonadReader env m
      , HasDogStatsClient env
@@ -83,8 +83,8 @@ withGauge
   => (EKG.Gauge -> IO ())
   -> Gauge
   -> m ()
-withGauge f Gauge {..} = do
+withEKGGauge f Gauge {..} = do
   current <- liftIO $ do
-    f atomic
-    EKG.read atomic
+    f ekgGauge
+    EKG.read ekgGauge
   gauge name tags $ fromIntegral current

--- a/library/Freckle/App/Datadog/Gauge.hs
+++ b/library/Freckle/App/Datadog/Gauge.hs
@@ -1,0 +1,90 @@
+-- | Stateful gauges for Datadog
+module Freckle.App.Datadog.Gauge
+  ( Gauge
+  , new
+  , increment
+  , decrement
+  , add
+  , subtract
+  ) where
+
+import Prelude hiding (subtract)
+
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Control.Monad.Reader
+import Data.Int (Int64)
+import Data.Text (Text)
+import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags, gauge)
+import qualified System.Metrics.Gauge as EKG
+
+-- | A data type containing all reporting values for a gauge
+data Gauge = Gauge
+  { name :: Text
+  , tags :: [(Text, Text)]
+  , atomic :: EKG.Gauge
+  }
+
+-- | Create a gauge holding in memory state
+new :: (MonadIO m) => Text -> [(Text, Text)] -> m Gauge
+new name tags = Gauge name tags <$> liftIO EKG.new
+
+-- | Increment gauge state and report its current value
+increment
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => Gauge
+  -> m ()
+increment = add 1
+
+-- | Add to gauge state and report its current value
+add
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => Int64
+  -> Gauge
+  -> m ()
+add i = withGauge (`EKG.add` i)
+
+-- | Decrement gauge state and report its current value
+decrement
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => Gauge
+  -> m ()
+decrement = subtract 1
+
+-- | Subtract from gauge state and report its current value
+subtract
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => Int64
+  -> Gauge
+  -> m ()
+subtract i = withGauge (`EKG.subtract` i)
+
+withGauge
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , HasDogStatsClient env
+     , HasDogStatsTags env
+     )
+  => (EKG.Gauge -> IO ())
+  -> Gauge
+  -> m ()
+withGauge f Gauge {..} = do
+  current <- liftIO $ do
+    f atomic
+    EKG.read atomic
+  gauge name tags $ fromIntegral current

--- a/library/Freckle/App/Datadog/Gauge.hs
+++ b/library/Freckle/App/Datadog/Gauge.hs
@@ -25,7 +25,7 @@ data Gauge = Gauge
   }
 
 -- | Create a gauge holding in memory state
-new :: (MonadIO m) => Text -> [(Text, Text)] -> m Gauge
+new :: MonadIO m => Text -> [(Text, Text)] -> m Gauge
 new name tags = Gauge name tags <$> liftIO EKG.new
 
 -- | Increment gauge state and report its current value

--- a/library/Freckle/App/RtsStats.hs
+++ b/library/Freckle/App/RtsStats.hs
@@ -51,12 +51,12 @@ flushEkgSample
   -> m ()
 flushEkgSample name = \case
   Ekg.Counter n -> Datadog.counter name [] $ fromIntegral n
-  Ekg.Gauge n -> Datadog.guage name [] $ fromIntegral n
+  Ekg.Gauge n -> Datadog.gauge name [] $ fromIntegral n
   Ekg.Distribution d -> do
-    Datadog.guage (name <> "." <> "mean") [] $ Ekg.mean d
-    Datadog.guage (name <> "." <> "variance") [] $ Ekg.variance d
-    Datadog.guage (name <> "." <> "sum") [] $ Ekg.sum d
-    Datadog.guage (name <> "." <> "min") [] $ Ekg.min d
-    Datadog.guage (name <> "." <> "max") [] $ Ekg.max d
+    Datadog.gauge (name <> "." <> "mean") [] $ Ekg.mean d
+    Datadog.gauge (name <> "." <> "variance") [] $ Ekg.variance d
+    Datadog.gauge (name <> "." <> "sum") [] $ Ekg.sum d
+    Datadog.gauge (name <> "." <> "min") [] $ Ekg.min d
+    Datadog.gauge (name <> "." <> "max") [] $ Ekg.max d
     Datadog.counter (name <> "." <> "count") [] $ fromIntegral $ Ekg.count d
   Ekg.Label _ -> pure ()


### PR DESCRIPTION
We still have a need for a stateful gauge in our application. There is
no reason to re-implement EKG's `Atomic`, so instead we can encapsulate
it and our associated use patterns.