### PR TITLE
Release 1.0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.0.4...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.1.0...main)
 
-None.
+- None.
+
+## [v1.0.1.0](https://github.com/freckle/freckle-app/compare/v1.0.1.0...v1.0.0.4)
+
+- Added `Freckle.App.Datadog.Gauge` for client side stateful gauges.
+- Added `Freckle.App.Datadog.Rts` for sending RTS statistics to DataDog.
 
 ## [v1.0.0.4](https://github.com/freckle/freckle-app/compare/v1.0.0.3...v1.0.0.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - None.
 
-## [v1.0.1.0](https://github.com/freckle/freckle-app/compare/v1.0.1.0...v1.0.0.4)
+## [v1.0.1.0](https://github.com/freckle/freckle-app/compare/v1.0.0.4...v1.0.1.0)
 
 - Added `Freckle.App.Datadog.Gauge` for client side stateful gauges.
 - Added `Freckle.App.Datadog.Rts` for sending RTS statistics to DataDog.

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.0.0.4
+version:        1.0.1.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils
@@ -35,6 +35,7 @@ library
       Freckle.App.Database
       Freckle.App.Datadog
       Freckle.App.Datadog.Gauge
+      Freckle.App.Datadog.Rts
       Freckle.App.Env
       Freckle.App.Env.Internal
       Freckle.App.Ghci
@@ -44,7 +45,6 @@ library
       Freckle.App.Http.Retry
       Freckle.App.Logging
       Freckle.App.RIO
-      Freckle.App.RtsStats
       Freckle.App.Test
       Freckle.App.Test.DocTest
       Freckle.App.Test.Hspec.Runner

--- a/library/Freckle/App/Datadog/Rts.hs
+++ b/library/Freckle/App/Datadog/Rts.hs
@@ -1,5 +1,5 @@
 -- | RTS statistics sent to Datadog
-module Freckle.App.RtsStats
+module Freckle.App.Datadog.Rts
   ( forkRtsStatPolling
   ) where
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.0.0.4
+version: 1.0.1.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
This is a minor version release via PVP rules.

- Added `Freckle.App.Datadog.Gauge` for client side stateful gauges.
- Added `Freckle.App.Datadog.Rts` for sending RTS statistics to DataDog.