### PR TITLE
Use Template Haskell to produce routes names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.1.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.0...main)
 
 - None.
+
+## [v1.0.2.0](https://github.com/freckle/freckle-app/compare/v1.0.1.0...v1.0.2.0)
+
+- Add 'Freckle.App.Yesod.Route' to allow printing route names.
 
 ## [v1.0.1.0](https://github.com/freckle/freckle-app/compare/v1.0.0.4...v1.0.1.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -51,6 +51,7 @@ library
       Freckle.App.Version
       Freckle.App.Wai
       Freckle.App.Yesod
+      Freckle.App.Yesod.Route
       Network.HTTP.Link.Compat
   other-modules:
       Paths_freckle_app
@@ -123,6 +124,7 @@ library
     , resource-pool
     , retry
     , rio
+    , template-haskell
     , text
     , time
     , transformers

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.0.1.0
+version:        1.0.2.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -51,7 +51,7 @@ library
       Freckle.App.Version
       Freckle.App.Wai
       Freckle.App.Yesod
-      Freckle.App.Yesod.Route
+      Freckle.App.Yesod.Routes
       Network.HTTP.Link.Compat
   other-modules:
       Paths_freckle_app

--- a/library/Freckle/App/Yesod/Route.hs
+++ b/library/Freckle/App/Yesod/Route.hs
@@ -1,0 +1,63 @@
+module Freckle.App.Yesod.Route
+  ( mkRouteNameCaseExp
+  ) where
+
+import Prelude
+
+import Data.Foldable (fold)
+import qualified Language.Haskell.TH as TH
+import Yesod.Routes.TH.Types
+
+-- | Lambdacase expression to print route names
+--
+-- It has the following type:
+--
+-- > _ :: Route a -> String
+--
+-- It produces code like:
+--
+-- > \case
+-- >   RoutePiece a -> case a of
+-- >     RouteResource{} -> "ResourceName"
+--
+mkRouteNameCaseExp :: [ResourceTree String] -> TH.Q TH.Exp
+mkRouteNameCaseExp tree = TH.LamCaseE . fold <$> traverse mkMatches tree
+
+-- | Make match expressions for a big case over routes
+--
+-- > RoutePiece a -> case a of
+-- >   ...
+--
+mkMatches :: ResourceTree String -> TH.Q [TH.Match]
+mkMatches (ResourceLeaf resource) = pure [mkLeafMatch resource]
+mkMatches (ResourceParent name _checkOverlap params children) = do
+  caseVar <- TH.newName "a"
+  let
+    paramVars =
+      fmap (const TH.WildP) (filter isDynamic params) <> [TH.VarP caseVar]
+  matches <- fold <$> traverse mkMatches children
+  pure
+    [ TH.Match
+        (TH.ConP constName paramVars)
+        (TH.NormalB $ TH.CaseE (TH.VarE caseVar) matches)
+        []
+    ]
+  where constName = TH.mkName name
+
+isDynamic :: Piece a -> Bool
+isDynamic = \case
+  Static{} -> False
+  Dynamic{} -> True
+
+-- | Leaf match expressions for a resource
+--
+-- > Name{} -> "ResourceName"
+--
+mkLeafMatch :: Resource String -> TH.Match
+mkLeafMatch resource = TH.Match
+  (TH.RecP constName [])
+  (TH.NormalB $ TH.LitE $ TH.StringL name)
+  []
+ where
+  constName = TH.mkName name
+  name = resourceName resource

--- a/library/Freckle/App/Yesod/Route.hs
+++ b/library/Freckle/App/Yesod/Route.hs
@@ -33,6 +33,7 @@ mkMatches (ResourceLeaf resource) = pure [mkLeafMatch resource]
 mkMatches (ResourceParent name _checkOverlap params children) = do
   caseVar <- TH.newName "a"
   let
+    -- by convention the final param in a route is the next route constructor
     paramVars =
       fmap (const TH.WildP) (filter isDynamic params) <> [TH.VarP caseVar]
   matches <- fold <$> traverse mkMatches children

--- a/library/Freckle/App/Yesod/Routes.hs
+++ b/library/Freckle/App/Yesod/Routes.hs
@@ -1,4 +1,4 @@
-module Freckle.App.Yesod.Route
+module Freckle.App.Yesod.Routes
   ( mkRouteNameCaseExp
   ) where
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.0.1.0
+version: 1.0.2.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app

--- a/package.yaml
+++ b/package.yaml
@@ -90,6 +90,7 @@ library:
     - resource-pool
     - retry
     - rio
+    - template-haskell
     - text
     - time
     - transformers


### PR DESCRIPTION
Yesod handles dispatch through abstract types and template haskell.
These opaque `Route a` types makes it hard to traverse the data without
manually unrolling the entire tree yourself. Instead we can use the same
methods that `yesod` uses internally to traverse `ResourceTree` and
produce the function from the route file itself.

This template haskell is pretty tame, it just builds a gigantic lambda
case expression nesting all of the routes and returning the leaf route
name at the end.

Other solutions are possible since we hold onto all `Static` and
`Dynamic` path names in the route file, but this method matches our
current use of `____R` resource names.