### PR TITLE
Add middleware for denying all HTML frame embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.1...main)
 
 - None.
+
+## [v1.0.2.1](https://github.com/freckle/freckle-app/compare/v1.0.2.0...v1.0.2.1)
+
+- Add `denyFrameEmbeddingMiddleware` for denying HTML frame embedding.
 
 ## [v1.0.2.0](https://github.com/freckle/freckle-app/compare/v1.0.1.0...v1.0.2.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.0.2.0
+version:        1.0.2.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Wai.hs
+++ b/library/Freckle/App/Wai.hs
@@ -8,6 +8,7 @@ module Freckle.App.Wai
   , makeRequestMetricsMiddleware
   , noCacheMiddleware
   , corsMiddleware
+  , denyFrameEmbeddingMiddleware
   ) where
 
 import Prelude
@@ -199,6 +200,10 @@ corsMiddleware
 corsMiddleware validateOrigin extraExposedHeaders =
   handleOptions validateOrigin extraExposedHeaders
     . addCORSHeaders validateOrigin extraExposedHeaders
+
+-- | Middleware that adds header to deny all frame embedding
+denyFrameEmbeddingMiddleware :: Middleware
+denyFrameEmbeddingMiddleware = addHeaders [("X-Frame-Options", "DENY")]
 
 handleOptions :: (ByteString -> Bool) -> [ByteString] -> Middleware
 handleOptions validateOrigin extraExposedHeaders app req sendResponse =

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.0.2.0
+version: 1.0.2.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
From the task

## Description
The "X-Frame-Options" header controls which origins are allowed to iframe the current page. The lack of this header can make many attacks such as XSS, CSRF, and Client-Side Account Takeover much more easily exploitable. Without the "X- Frame-Options" header it is also possible to perform click-jacking attacks which may have high impact depending on the application.

## Remediation
It is recommended that the "X-Frame-Options" be added to the response headers throughout the application in order to prevent easy exploitation of client-side bugs and click-jacking. 