### PR TITLE
Update to hspec-unit-formatter-1.1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.2...main)
 
 - None.
+
+## [v1.0.2.2](https://github.com/freckle/freckle-app/compare/v1.0.2.1...v1.0.2.2)
+
+- Target `hspec-junit-formatter-1.0.3.0` (use `1.1.0.0` in development)
 
 ## [v1.0.2.1](https://github.com/freckle/freckle-app/compare/v1.0.2.0...v1.0.2.1)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.0.2.1
+version:        1.0.2.2
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Test/Hspec/Runner.hs
+++ b/library/Freckle/App/Test/Hspec/Runner.hs
@@ -3,8 +3,7 @@ module Freckle.App.Test.Hspec.Runner
   , runParConfig
   , runWith
   , makeParallelConfig
-  )
-where
+  ) where
 
 import Prelude
 
@@ -14,12 +13,15 @@ import Control.Monad (void)
 import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
 import Data.List (isInfixOf)
 import Data.Maybe (fromMaybe, isJust)
+import Data.Text (pack)
 import System.Environment (getArgs, lookupEnv)
-import Test.HSpec.JUnit (runJUnitSpec)
 import Test.Hspec (Spec)
+import Test.Hspec.JUnit
+  (configWithJUnit, defaultJUnitConfig, setJUnitConfigOutputFile)
 import Test.Hspec.Runner
   ( Config
   , Path
+  , Summary
   , configConcurrentJobs
   , configSkipPredicate
   , defaultConfig
@@ -64,6 +66,14 @@ runWith config name spec = do
     (spec `runJUnitSpec` ("/tmp/junit", filename)) . changeConfig
   hspec _ changeConfig = runSpec spec . changeConfig
   noConcurrency x = x { configConcurrentJobs = Just 1 }
+
+runJUnitSpec :: Spec -> (FilePath, String) -> Config -> IO Summary
+runJUnitSpec spec (path, name) config =
+  spec `runSpec` configWithJUnit junitConfig config
+ where
+  filePath = path <> "/" <> name <> "/test_results.xml"
+  junitConfig =
+    setJUnitConfigOutputFile filePath $ defaultJUnitConfig $ pack name
 
 makeParallelConfig :: Config -> IO Config
 makeParallelConfig config = do

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.0.2.1
+version: 1.0.2.2
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,10 @@
-resolver: lts-18.2
+resolver: lts-18.18
+
+extra-deps:
+  - hspec-2.9.3
+  - hspec-core-2.9.3
+  - hspec-discover-2.9.3
+  - hspec-junit-formatter-1.1.0.0
 
 ghc-options:
   "$locals": >-

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,38 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: hspec-2.9.3@sha256:9b54d0c8ef8b3114aa39465a7b24658c987fbd6aab1479eafc00ee31da1be1de,1709
+    pantry-tree:
+      size: 583
+      sha256: c4dc568111385baea4bd240d87fecf8df1d74474cca79b05e7af6009a7155550
+  original:
+    hackage: hspec-2.9.3
+- completed:
+    hackage: hspec-core-2.9.3@sha256:7ee9b50fa446eb05d8feb2314991fc836c914d5d2c3bda88e6dd272b38389325,6498
+    pantry-tree:
+      size: 5684
+      sha256: 5f05075378d26124143b2bff028325338ace9e6d5fbbc74b1671ff367aaabb6c
+  original:
+    hackage: hspec-core-2.9.3
+- completed:
+    hackage: hspec-discover-2.9.3@sha256:9546ec2f89cff3770f470866bc47fb4b197c1d3180a862ccb053533133b4f8ee,2165
+    pantry-tree:
+      size: 828
+      sha256: 5dca3f547fdb3f42d01eeb5bafd9d9b852d0cd6d8f5ed16b13fc257cff86285b
+  original:
+    hackage: hspec-discover-2.9.3
+- completed:
+    hackage: hspec-junit-formatter-1.1.0.0@sha256:c2f453440fc526cfd8f880b67876ac64d6e0fa13c8e94722a86e7996882e8ed0,3825
+    pantry-tree:
+      size: 955
+      sha256: 23789fad1b4c65150a29c6071fa47df58b7a36b9b6af818bb481f98b34fe6811
+  original:
+    hackage: hspec-junit-formatter-1.1.0.0
 snapshots:
 - completed:
-    size: 585392
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/2.yaml
-    sha256: 7abb45c0cc5eb349448b66d8753655542d45d387ad26970419282eab3d860724
-  original: lts-18.2
+    size: 586296
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
+    sha256: 63539429076b7ebbab6daa7656cfb079393bf644971156dc349d7c0453694ac2
+  original: lts-18.18


### PR DESCRIPTION
This version removed `runJUnitSpec` in favor of functions better-suited to the
common case (e.g. `hspecJUnit`). This, however, is not the common case.

We are running three suites separately and evaluating everything once at the
end. Therefore, we have to dig around in hspec internals a little more and
re-implement `runJUNitSpec` ourselves.
