### PR TITLE
Add Freckle-specific prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.2...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.3...main)
 
 - None.
+
+## [v1.0.2.3](https://github.com/freckle/freckle-app/compare/v1.0.2.2...v1.0.2.3)
+
+- Add Freckle-specific prelude.
 
 ## [v1.0.2.2](https://github.com/freckle/freckle-app/compare/v1.0.2.1...v1.0.2.2)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.0.2.2
+version:        1.0.2.3
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils
@@ -44,6 +44,7 @@ library
       Freckle.App.Http.Paginate
       Freckle.App.Http.Retry
       Freckle.App.Logging
+      Freckle.App.Prelude
       Freckle.App.RIO
       Freckle.App.Test
       Freckle.App.Test.DocTest
@@ -91,6 +92,7 @@ library
     , bytestring
     , case-insensitive
     , conduit
+    , containers
     , data-default
     , datadog
     , doctest
@@ -99,6 +101,7 @@ library
     , exceptions
     , fast-logger
     , filepath
+    , hashable
     , hspec
     , hspec-core
     , hspec-expectations-lifted
@@ -124,6 +127,8 @@ library
     , resource-pool
     , retry
     , rio
+    , safe
+    , semigroupoids
     , template-haskell
     , text
     , time
@@ -132,6 +137,7 @@ library
     , unliftio
     , unliftio-core
     , unordered-containers
+    , vector
     , wai
     , wai-extra
     , yaml

--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -22,11 +22,10 @@ module Freckle.App.Database
   , envPostgresPasswordSource
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Concurrent
 import qualified Control.Immortal as Immortal
-import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Logger (runNoLoggingT)
 import Control.Monad.Reader
 import Data.ByteString (ByteString)
@@ -35,12 +34,12 @@ import Data.Char (isDigit)
 import Data.IORef
 import Data.Pool
 import qualified Data.Text as T
-import Data.Time (UTCTime, getCurrentTime)
 import Database.Persist.Postgresql
 import Database.PostgreSQL.Simple
   (Connection, Only(..), connectPostgreSQL, execute)
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import qualified Freckle.App.Env as Env
+import qualified Prelude as Unsafe (read)
 import System.Process (readProcess)
 
 type SqlPool = Pool SqlBackend
@@ -117,9 +116,10 @@ readPostgresStatementTimeout
   :: String -> Either String PostgresStatementTimeout
 readPostgresStatementTimeout x = case span isDigit x of
   ("", _) -> Left "must be {digits}(s|ms)"
-  (digits, "") -> Right $ PostgresStatementTimeoutSeconds $ read digits
-  (digits, "s") -> Right $ PostgresStatementTimeoutSeconds $ read digits
-  (digits, "ms") -> Right $ PostgresStatementTimeoutMilliseconds $ read digits
+  (digits, "") -> Right $ PostgresStatementTimeoutSeconds $ Unsafe.read digits
+  (digits, "s") -> Right $ PostgresStatementTimeoutSeconds $ Unsafe.read digits
+  (digits, "ms") ->
+    Right $ PostgresStatementTimeoutMilliseconds $ Unsafe.read digits
   _ -> Left "must be {digits}(s|ms)"
 
 envPostgresPasswordSource :: Env.Parser PostgresPasswordSource

--- a/library/Freckle/App/Datadog.hs
+++ b/library/Freckle/App/Datadog.hs
@@ -32,14 +32,11 @@ module Freckle.App.Datadog
   , guage
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Lens (set)
-import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Reader
-import Data.Foldable (for_)
-import Data.Text (Text)
-import Data.Time (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import Data.Time (diffUTCTime)
 import qualified Freckle.App.Env as Env
 import Network.StatsD.Datadog hiding (metric, name, tags)
 import qualified Network.StatsD.Datadog as Datadog

--- a/library/Freckle/App/Datadog/Gauge.hs
+++ b/library/Freckle/App/Datadog/Gauge.hs
@@ -8,12 +8,8 @@ module Freckle.App.Datadog.Gauge
   , subtract
   ) where
 
-import Prelude hiding (subtract)
+import Freckle.App.Prelude hiding (subtract)
 
-import Control.Monad.IO.Unlift (MonadUnliftIO)
-import Control.Monad.Reader
-import Data.Int (Int64)
-import Data.Text (Text)
 import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags, gauge)
 import qualified System.Metrics.Gauge as EKG
 

--- a/library/Freckle/App/Datadog/Rts.hs
+++ b/library/Freckle/App/Datadog/Rts.hs
@@ -3,15 +3,10 @@ module Freckle.App.Datadog.Rts
   ( forkRtsStatPolling
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import qualified Control.Immortal as Immortal
-import Control.Monad (void)
-import Control.Monad.IO.Unlift (MonadUnliftIO, liftIO)
-import Control.Monad.Reader (MonadReader)
-import Data.Foldable (traverse_)
 import qualified Data.HashMap.Strict as HashMap
-import Data.Text (Text)
 import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags)
 import qualified Freckle.App.Datadog as Datadog
 import qualified System.Metrics as Ekg

--- a/library/Freckle/App/Env.hs
+++ b/library/Freckle/App/Env.hs
@@ -43,15 +43,13 @@ module Freckle.App.Env
   -- * Modifiers
   , def
   , nonEmpty
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Error.Util (note)
-import Data.Bifunctor (first, second)
 import Data.String
-import Data.Text (Text, pack, unpack)
+import Data.Text (pack, unpack)
 import qualified Data.Text as T
 import Data.Time
 import Freckle.App.Env.Internal

--- a/library/Freckle/App/Env/Internal.hs
+++ b/library/Freckle/App/Env/Internal.hs
@@ -9,13 +9,11 @@ module Freckle.App.Env.Internal
   , Mod(..)
   , Var(..)
   , varParser
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Applicative
-import Data.Bifunctor (first)
 
 -- | Environment parsing errors
 data Error

--- a/library/Freckle/App/Ghci.hs
+++ b/library/Freckle/App/Ghci.hs
@@ -3,12 +3,10 @@ module Freckle.App.Ghci
   , runDB'
   , loadEnv
   , loadEnvTest
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Control.Monad.Reader (ReaderT)
 import Database.Persist.Postgresql (runSqlPool)
 import Database.Persist.Sql (SqlBackend)
 import Freckle.App.Database (makePostgresPool)

--- a/library/Freckle/App/GlobalCache.hs
+++ b/library/Freckle/App/GlobalCache.hs
@@ -48,13 +48,11 @@ module Freckle.App.GlobalCache
   , newGlobalCache
   , globallyCache
   , withGlobalCacheCleanup
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Concurrent.MVar (mkWeakMVar, modifyMVar_, newMVar)
-import Control.Monad (void)
 import Data.IORef
 
 newtype GlobalCache a = GlobalCache

--- a/library/Freckle/App/Http.hs
+++ b/library/Freckle/App/Http.hs
@@ -117,17 +117,14 @@ module Freckle.App.Http
   , statusIsServerError
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Conduit (foldC, mapMC, runConduit, (.|))
-import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
-import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
-import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import Freckle.App.Http.Paginate
 import Freckle.App.Http.Retry
@@ -159,7 +156,7 @@ instance Exception HttpDecodeError where
       <> fromErrors hdeErrors
    where
     fromErrors = \case
-      err :| [] -> ["Error:", err]
+      err NE.:| [] -> ["Error:", err]
       errs -> "Errors:" : map bullet (NE.toList errs)
     bullet = (" • " <>)
 

--- a/library/Freckle/App/Http/Paginate.hs
+++ b/library/Freckle/App/Http/Paginate.hs
@@ -57,13 +57,10 @@ module Freckle.App.Http.Paginate
   , sourcePaginatedBy
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Conduit
 import Control.Error.Util (hush)
-import Data.Foldable (traverse_)
-import Data.List (find)
-import Data.Maybe (listToMaybe)
 import Data.Text.Encoding (decodeUtf8)
 import Network.HTTP.Link.Compat hiding (linkHeader)
 import Network.HTTP.Simple

--- a/library/Freckle/App/Http/Retry.hs
+++ b/library/Freckle/App/Http/Retry.hs
@@ -4,13 +4,10 @@ module Freckle.App.Http.Retry
   , rateLimited'
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Control.Monad (guard, unless, void)
-import Control.Monad.IO.Class (MonadIO)
 import Control.Retry
 import qualified Data.ByteString.Char8 as BS8
-import Data.Maybe (listToMaybe)
 import Network.HTTP.Client (Request(..))
 import Network.HTTP.Simple
 import Network.HTTP.Types.Status (status429)

--- a/library/Freckle/App/Logging.hs
+++ b/library/Freckle/App/Logging.hs
@@ -23,10 +23,9 @@ module Freckle.App.Logging
   , formatJsonNoLoc
   , formatJson
   , formatTerminal
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Monad.Logger
 import Data.Aeson (ToJSON, encode, object, (.=))
@@ -34,7 +33,6 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BSL
-import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import qualified Freckle.App.Env as Env
 import System.Console.ANSI

--- a/library/Freckle/App/Prelude.hs
+++ b/library/Freckle/App/Prelude.hs
@@ -1,0 +1,147 @@
+-- | Those functions and types we can't do without!
+module Freckle.App.Prelude
+  (
+  -- * 'Prelude' as the starting point, without common partial functions
+    module Prelude
+
+  -- * Commonly imported types
+  , Alternative
+  , Exception
+  , Generic
+  , HashMap
+  , HashSet
+  , Hashable
+  , Int64
+  , Map
+  , MonadIO
+  , MonadReader
+  , MonadUnliftIO
+  , NominalDiffTime
+  , NonEmpty
+  , PrimMonad
+  , ReaderT
+  , Set
+  , Text
+  , UTCTime
+  , Vector
+
+  -- * Commonly used functions
+
+  -- ** Lifts
+  , lift
+  , liftIO
+
+  -- ** 'Text'
+  , tshow
+
+  -- ** 'Maybe'
+  , catMaybes
+  , fromMaybe
+  , isJust
+  , isNothing
+  , listToMaybe
+  , mapMaybe
+  , maybeToList
+
+  -- ** Safe alternatives to partial prelude functions (e.g. 'headMay')
+  , module SafeAlternatives
+
+  -- ** 'Either'
+  , partitionEithers
+
+  -- ** 'Foldable'
+  , module Foldable
+
+  -- ** 'Traversable'
+  , module Traversable
+
+  -- ** 'Functor'
+  , (<$$>)
+
+  -- ** 'Bifunctor'
+  , bimap
+  , first
+  , second
+
+  -- ** 'Applicative'
+  , (<|>)
+  , liftA2
+  , optional
+
+  -- ** 'Monad'
+  , (<=<)
+  , (>=>)
+  , guard
+  , join
+  , unless
+  , void
+  , when
+
+  -- ** 'Arrow'
+  , (&&&)
+  , (***)
+
+  -- ** 'UTCTime'
+  , getCurrentTime
+  ) where
+
+-- Use 'Prelude' as the starting point, removing common partial functions
+
+import Prelude hiding
+  (cycle, foldl1, foldr1, head, init, last, maximum, minimum, read, tail, (!!))
+
+-- Commonly used types (and their commonly used functions)
+
+import Control.Applicative (Alternative, liftA2, optional, (<|>))
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Primitive (PrimMonad)
+import Control.Monad.Reader (MonadReader, ReaderT)
+import Data.HashMap.Strict (HashMap)
+import Data.HashSet (HashSet)
+import Data.Hashable (Hashable)
+import Data.Int (Int64)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map.Strict (Map)
+import Data.Set (Set)
+import Data.Text (Text)
+import Data.Time (NominalDiffTime, UTCTime, getCurrentTime)
+import Data.Vector (Vector)
+import GHC.Generics (Generic)
+import UnliftIO (MonadUnliftIO)
+import UnliftIO.Exception (Exception)
+
+-- Safe alternatives to prelude functions
+
+import Data.Semigroup.Foldable as SafeAlternatives (fold1, foldMap1)
+import Safe as SafeAlternatives
+  ( atMay
+  , cycleMay
+  , headMay
+  , initMay
+  , lastMay
+  , maximumMay
+  , minimumMay
+  , readMay
+  , tailMay
+  )
+
+-- Commonly used functions
+
+import Control.Arrow ((&&&), (***))
+import Control.Monad (guard, join, unless, void, when, (<=<), (>=>))
+import Control.Monad.Trans (lift)
+import Data.Bifunctor (bimap, first, second)
+import Data.Either (partitionEithers)
+import Data.Foldable as Foldable hiding (foldl1, foldr1)
+import Data.Maybe
+  (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
+import qualified Data.Text as T
+import Data.Traversable as Traversable
+
+infixl 4 <$$>
+(<$$>) :: (Functor c, Functor d) => (a -> b) -> c (d a) -> c (d b)
+f <$$> as = (f <$>) <$> as
+
+-- | 'Show' as 'Text'
+tshow :: Show a => a -> Text
+tshow = T.pack . show

--- a/library/Freckle/App/RIO.hs
+++ b/library/Freckle/App/RIO.hs
@@ -11,14 +11,11 @@ module Freckle.App.RIO
   ( toAppLogLevel
   , fromAppLogLevel
   , makeLogFunc
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Control.Monad (when)
 import Control.Monad.Logger (Loc(..), LogLevel(..))
-import Data.Maybe (fromMaybe, listToMaybe)
 import Freckle.App.Logging
 import GHC.Exception (CallStack, SrcLoc(..), getCallStack)
 import qualified RIO

--- a/library/Freckle/App/Test.hs
+++ b/library/Freckle/App/Test.hs
@@ -11,11 +11,10 @@ module Freckle.App.Test
   , module X
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Monad.Base
 import Control.Monad.Catch
-import Control.Monad.IO.Unlift
 import Control.Monad.Logger
 import Control.Monad.Primitive
 import Control.Monad.Random (MonadRandom(..))

--- a/library/Freckle/App/Test/DocTest.hs
+++ b/library/Freckle/App/Test/DocTest.hs
@@ -7,14 +7,12 @@ module Freckle.App.Test.DocTest
   -- * Lower-level, for site-specific use
   , findPackageFlags
   , findDocTestedFiles
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
 import Control.Monad (filterM)
 import Data.Aeson
-import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Yaml (decodeFileThrow)
@@ -33,8 +31,7 @@ doctestWith flags dir = do
   DocTest.doctest $ packageFlags <> flags <> sourceFiles
 
 -- | Representation of only the information we need in a @package.yaml@
-data PackageYaml
-  = PackageYaml
+data PackageYaml = PackageYaml
   { defaultExtensions :: [String]
   , name :: String
   }

--- a/library/Freckle/App/Test/Hspec/Runner.hs
+++ b/library/Freckle/App/Test/Hspec/Runner.hs
@@ -5,15 +5,13 @@ module Freckle.App.Test.Hspec.Runner
   , makeParallelConfig
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Control.Applicative ((<|>))
 import Control.Concurrent (getNumCapabilities, setNumCapabilities)
-import Control.Monad (void)
 import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
 import Data.List (isInfixOf)
-import Data.Maybe (fromMaybe, isJust)
 import Data.Text (pack)
+import qualified Prelude as Unsafe (read)
 import System.Environment (getArgs, lookupEnv)
 import Test.Hspec (Spec)
 import Test.Hspec.JUnit
@@ -86,7 +84,7 @@ makeParallelConfig config = do
   pure config { configConcurrentJobs = Just $ jobCores * 4 }
 
 lookupTestCapabilities :: IO (Maybe Int)
-lookupTestCapabilities = fmap read <$> lookupEnv "TEST_CAPABILITIES"
+lookupTestCapabilities = fmap Unsafe.read <$> lookupEnv "TEST_CAPABILITIES"
 
 lookupHostCapabilities :: IO (Maybe Int)
 lookupHostCapabilities = Just . reduceCapabilities <$> getNumCapabilities

--- a/library/Freckle/App/Version.hs
+++ b/library/Freckle/App/Version.hs
@@ -8,22 +8,16 @@ module Freckle.App.Version
   ( AppVersion(..)
   , getAppVersion
   , tryGetAppVersion
-  )
-where
+  ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Control.Applicative ((<|>))
 import Control.Error.Util (hoistEither, note)
-import Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Trans.Except
-import Data.Bifunctor (first)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
-import Data.Text (Text, pack)
+import Data.Text (pack)
 import qualified Data.Text as T
-import Data.Time (UTCTime, getCurrentTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeM)
 import System.Exit (ExitCode(..))
 import System.FilePath ((</>))

--- a/library/Freckle/App/Wai.hs
+++ b/library/Freckle/App/Wai.hs
@@ -11,14 +11,11 @@ module Freckle.App.Wai
   , denyFrameEmbeddingMiddleware
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Control.Applicative ((<|>))
-import Control.Monad (guard)
 import Control.Monad.Logger (LogLevel(..))
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson
-import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.ByteString.Builder (toLazyByteString)
@@ -27,11 +24,9 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.CaseInsensitive as CI
 import Data.Default (def)
 import Data.IP (fromHostAddress, fromHostAddress6)
-import Data.Maybe (fromMaybe, maybeToList)
-import Data.Text (Text, pack)
+import Data.Text (pack)
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
-import Data.Time (getCurrentTime)
 import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags)
 import qualified Freckle.App.Datadog as Datadog
 import Freckle.App.Logging

--- a/library/Freckle/App/Yesod.hs
+++ b/library/Freckle/App/Yesod.hs
@@ -8,9 +8,8 @@ module Freckle.App.Yesod
   , respondQueryCanceledHeaders
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Control.Monad (guard, when)
 import Control.Monad.Logger
 import Data.Text (pack)
 import Database.PostgreSQL.Simple (SqlError(..))

--- a/library/Freckle/App/Yesod/Routes.hs
+++ b/library/Freckle/App/Yesod/Routes.hs
@@ -2,9 +2,8 @@ module Freckle.App.Yesod.Routes
   ( mkRouteNameCaseExp
   ) where
 
-import Prelude
+import Freckle.App.Prelude
 
-import Data.Foldable (fold)
 import qualified Language.Haskell.TH as TH
 import Yesod.Routes.TH.Types
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.0.2.2
+version: 1.0.2.3
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app
@@ -57,6 +57,7 @@ library:
     - bytestring
     - case-insensitive
     - conduit
+    - containers
     - data-default
     - datadog
     - doctest
@@ -65,6 +66,7 @@ library:
     - exceptions
     - fast-logger
     - filepath
+    - hashable
     - hspec
     - hspec-core
     - hspec-expectations-lifted
@@ -90,6 +92,8 @@ library:
     - resource-pool
     - retry
     - rio
+    - safe
+    - semigroupoids
     - template-haskell
     - text
     - time
@@ -98,6 +102,7 @@ library:
     - unliftio
     - unliftio-core
     - unordered-containers
+    - vector
     - wai
     - wai-extra
     - yaml


### PR DESCRIPTION
**Why?**

In removing `classy-prelude` from our monorepo, a ton of import ergonomics have
been lost. This attempts to recover some of those ergonomics and also be the
starting point for our very own prelude.

This was mostly inspired by the things I had to import a gazillion types when
removing `classy-prelude` from a few of our libraries. Before hitting the
library that has the most instances, I thought it'd be nice to have something
like this in place.

**Things to look out for**

 - Did I export too much?
 - Are there glaring omissions?
 - Did I pick the wrong thing in some case (e.g. is `Control.Monad.Reader` the
 - "right" reader?)
 - Should this move into our monorepo?
 - Should I get a dep from another package? All new packages were hidden deps, which is nice, but should I have instead just squashed RIO + Prelude?
  - Do _YOU_ specifically have a prelude preference that we should consider instead?
  - Should this be in freckle-app or elsewhere?

**Note on reviewing**

This is likely controversial so I'll be sure to eyes from all interested
backenders.