### PR TITLE
Remove explicit region specification in DB token generation

### DIFF
--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -174,8 +174,6 @@ createAuroraIamToken aitPostgresConnectionConf@PostgresConnectionConf {..} = do
     , pccHost
     , "--port"
     , show pccPort
-    , "--region"
-    , "us-east-1"
     , "--username"
     , pccUser
     ]


### PR DESCRIPTION
This hard-coded region prevents deploys of `freckle-app` backed by IAM auth outside of `us-east-1`. We can remove it and allow for region discovery in AWS environments to populate as desired (assuming co-location of the deployment with the target DB).