### PR TITLE
Add some common textual encoding functions to prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - None.
 
+## [v1.0.2.9](https://github.com/freckle/freckle-app/compare/v1.0.2.8...v1.0.2.9)
+
+- Add some common textual encoding functions to prelude
+
 ## [v1.0.2.8](https://github.com/freckle/freckle-app/compare/v1.0.2.7...v1.0.2.8)
 
 - Don't allow `aeson-2.0`

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.0.2.8
+version:        1.0.2.9
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Env.hs
+++ b/library/Freckle/App/Env.hs
@@ -49,7 +49,6 @@ import Freckle.App.Prelude
 
 import Control.Error.Util (note)
 import Data.String
-import Data.Text (pack, unpack)
 import qualified Data.Text as T
 import Data.Time
 import Freckle.App.Env.Internal

--- a/library/Freckle/App/Http/Paginate.hs
+++ b/library/Freckle/App/Http/Paginate.hs
@@ -61,7 +61,6 @@ import Freckle.App.Prelude
 
 import Conduit
 import Control.Error.Util (hush)
-import Data.Text.Encoding (decodeUtf8)
 import Network.HTTP.Link.Compat hiding (linkHeader)
 import Network.HTTP.Simple
 

--- a/library/Freckle/App/Logging.hs
+++ b/library/Freckle/App/Logging.hs
@@ -33,7 +33,6 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BSL
-import Data.Text.Encoding (decodeUtf8)
 import qualified Freckle.App.Env as Env
 import System.Console.ANSI
   ( Color(Blue, Magenta, Red, Yellow)

--- a/library/Freckle/App/Prelude.hs
+++ b/library/Freckle/App/Prelude.hs
@@ -33,6 +33,10 @@ module Freckle.App.Prelude
 
   -- ** 'Text'
   , tshow
+  , pack
+  , unpack
+  , encodeUtf8
+  , decodeUtf8
 
   -- ** 'Maybe'
   , catMaybes
@@ -103,7 +107,7 @@ import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
 import Data.Set (Set)
-import Data.Text (Text)
+import Data.Text (Text, pack, unpack)
 import Data.Time (NominalDiffTime, UTCTime, getCurrentTime)
 import Data.Vector (Vector)
 import GHC.Generics (Generic)
@@ -135,7 +139,7 @@ import Data.Either (partitionEithers)
 import Data.Foldable as Foldable hiding (foldl1, foldr1)
 import Data.Maybe
   (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
-import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Traversable as Traversable
 
 infixl 4 <$$>
@@ -144,4 +148,4 @@ f <$$> as = (f <$>) <$> as
 
 -- | 'Show' as 'Text'
 tshow :: Show a => a -> Text
-tshow = T.pack . show
+tshow = pack . show

--- a/library/Freckle/App/Test/Hspec/Runner.hs
+++ b/library/Freckle/App/Test/Hspec/Runner.hs
@@ -10,7 +10,6 @@ import Freckle.App.Prelude
 import Control.Concurrent (getNumCapabilities, setNumCapabilities)
 import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
 import Data.List (isInfixOf)
-import Data.Text (pack)
 import qualified Prelude as Unsafe (read)
 import System.Environment (getArgs, lookupEnv)
 import Test.Hspec (Spec)

--- a/library/Freckle/App/Version.hs
+++ b/library/Freckle/App/Version.hs
@@ -16,7 +16,6 @@ import Control.Error.Util (hoistEither, note)
 import Control.Monad.Trans.Except
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
-import Data.Text (pack)
 import qualified Data.Text as T
 import Data.Time.Format (defaultTimeLocale, parseTimeM)
 import System.Exit (ExitCode(..))

--- a/library/Freckle/App/Wai.hs
+++ b/library/Freckle/App/Wai.hs
@@ -11,7 +11,7 @@ module Freckle.App.Wai
   , denyFrameEmbeddingMiddleware
   ) where
 
-import Freckle.App.Prelude
+import Freckle.App.Prelude hiding (decodeUtf8)
 
 import Control.Monad.Logger (LogLevel(..))
 import Control.Monad.Reader (runReaderT)
@@ -24,7 +24,6 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.CaseInsensitive as CI
 import Data.Default (def)
 import Data.IP (fromHostAddress, fromHostAddress6)
-import Data.Text (pack)
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags)

--- a/library/Freckle/App/Yesod.hs
+++ b/library/Freckle/App/Yesod.hs
@@ -11,7 +11,6 @@ module Freckle.App.Yesod
 import Freckle.App.Prelude
 
 import Control.Monad.Logger
-import Data.Text (pack)
 import Database.PostgreSQL.Simple (SqlError(..))
 import Freckle.App.Datadog (HasDogStatsClient, HasDogStatsTags)
 import qualified Freckle.App.Datadog as Datadog

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.0.2.8
+version: 1.0.2.9
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
These were discussed in backend guild as being common enough that we should
include them in `Freckle.App.Prelude`.