### PR TITLE
Simplify getRouteName, getTraceId to getTags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
 
   And similar for `makeRequestMetricsMiddleware`.
 
-
 ## [v1.0.2.9](https://github.com/freckle/freckle-app/compare/v1.0.2.8...v1.0.2.9)
 
 - Add some common textual encoding functions to prelude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.0.2.8...main)
 
-- None.
+- Change `Wai` function arguments for producing `RouteName` and `TraceId` to
+  tags
+
+  To maintain the same behavior, replace
+
+  ```hs
+  makeLoggingMiddleware app getRouteName getTraceId ...
+  ```
+
+  With
+
+  ```hs
+  makeLoggingMiddleware app getTags ...
+    where
+      getTags req = catMaybes
+        [ ("route", ) <$> getRouteName req
+        , ("trace_id", ) <$> getTraceId req
+        ]
+  ```
+
+  And similar for `makeRequestMetricsMiddleware`.
+
 
 ## [v1.0.2.9](https://github.com/freckle/freckle-app/compare/v1.0.2.8...v1.0.2.9)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 1.18
 
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
@@ -16,9 +16,10 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
+    package.yaml
+extra-doc-files:
     README.md
     CHANGELOG.md
-    package.yaml
 
 source-repository head
   type: git

--- a/package.yaml
+++ b/package.yaml
@@ -7,9 +7,11 @@ github: freckle/freckle-app
 synopsis: Haskell application toolkit used at Freckle
 description: Please see README.md
 
-extra-source-files:
+extra-doc-files:
   - README.md
   - CHANGELOG.md
+
+extra-source-files:
   - package.yaml
 
 flags:


### PR DESCRIPTION
By accepting a generic producer of [(Text, Text)], callers can supply
the same route (and trace_id) values we are using today, but also be
able to supply any others (without blowing up the interface).

Concretely, this will be used to add a Freckle Team as the "owner" tag
to everything we emit from our Haskell APIs.
