### PR TITLE
Migrate Bugsnag handling

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -33,6 +33,7 @@ flag test-git
 library
   exposed-modules:
       Freckle.App
+      Freckle.App.Bugsnag
       Freckle.App.Database
       Freckle.App.Datadog
       Freckle.App.Datadog.Gauge
@@ -98,6 +99,7 @@ library
     , aeson
     , ansi-terminal
     , base <5
+    , bugsnag
     , bytestring
     , case-insensitive
     , conduit
@@ -245,6 +247,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Freckle.App.BugsnagSpec
       Freckle.App.Env.InternalSpec
       Freckle.App.HttpSpec
       Freckle.App.Memcached.ServersSpec
@@ -293,6 +296,7 @@ test-suite spec
     , memcache
     , monad-logger
     , mtl
+    , postgresql-simple
     , unliftio-core
     , wai
     , wai-extra

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -28,6 +28,7 @@ import Control.Monad.Reader (runReaderT)
 import Data.Bugsnag
 import Data.Bugsnag.Settings
 import qualified Data.ByteString.Char8 as BS8
+import Data.List (isInfixOf)
 import Database.PostgreSQL.Simple (SqlError(..))
 import Database.PostgreSQL.Simple.Errors
 import qualified Freckle.App.Env as Env
@@ -141,8 +142,7 @@ asHttpException (InvalidUrlException url msg) = updateExceptions $ \ex -> ex
 -- Marking them as not in-project does this, with little downside.
 --
 maskErrorHelpers :: BeforeNotify
-maskErrorHelpers = setStackFramesInProjectByFile (`notElem` errorHelpers)
-  where errorHelpers = ["library/FrontRow/Core/Exceptions.hs"]
+maskErrorHelpers = setStackFramesInProjectByFile (`isInfixOf` "Exceptions")
 
 -- brittany-disable-next-binding
 

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -1,0 +1,164 @@
+module Freckle.App.Bugsnag
+  ( Settings
+  , HasBugsnagSettings(..)
+  , notifyBugsnag
+  , notifyBugsnagWith
+
+  -- * 'AppVersion'
+  , HasAppVersion(..)
+  , setAppVersion
+
+  -- * Loading settings
+  , envParseBugsnagSettings
+
+  -- * Exported for testing
+  , sqlErrorGroupingHash
+
+  -- * Re-exports
+  , MonadReader
+  , runReaderT
+  , module Network.Bugsnag
+  ) where
+
+import Freckle.App.Prelude
+
+import Control.Concurrent (forkIO)
+import Control.Lens (Lens', view)
+import Control.Monad.Reader (runReaderT)
+import Data.Bugsnag
+import Data.Bugsnag.Settings
+import qualified Data.ByteString.Char8 as BS8
+import Database.PostgreSQL.Simple (SqlError(..))
+import Database.PostgreSQL.Simple.Errors
+import qualified Freckle.App.Env as Env
+import Freckle.App.Version
+import Network.Bugsnag hiding (notifyBugsnag, notifyBugsnagWith)
+import qualified Network.Bugsnag as Bugsnag
+import Network.HTTP.Client (HttpException(..), host, method)
+import qualified UnliftIO.Exception as Exception
+import Yesod.Core.Lens
+import Yesod.Core.Types (HandlerData)
+
+class HasAppVersion env where
+  appVersionL :: Lens' env AppVersion
+
+instance HasAppVersion AppVersion where
+  appVersionL = id
+
+instance HasAppVersion site =>  HasAppVersion (HandlerData child site) where
+  appVersionL = envL . siteL . appVersionL
+
+setAppVersion :: AppVersion -> BeforeNotify
+setAppVersion AppVersion {..} = updateEvent $ \event ->
+  event { event_app = Just $ defaultApp { app_version = Just avName } }
+
+class HasBugsnagSettings env where
+  bugsnagSettingsL :: Lens' env Settings
+
+instance HasBugsnagSettings Settings where
+  bugsnagSettingsL = id
+
+instance HasBugsnagSettings site =>  HasBugsnagSettings (HandlerData child site) where
+  bugsnagSettingsL = envL . siteL . bugsnagSettingsL
+
+-- | Notify Bugsnag of an exception
+--
+-- The notification is made asynchronously via a simple @'forkIO'@. This is
+-- best-effort and we don't care to keep track of the spawned threads.
+--
+notifyBugsnag
+  :: ( MonadIO m
+     , MonadReader env m
+     , HasBugsnagSettings env
+     , Exception.Exception e
+     )
+  => e
+  -> m ()
+notifyBugsnag = notifyBugsnagWith mempty
+
+-- | 'notifyBugsnag' with a 'BeforeNotify'
+notifyBugsnagWith
+  :: ( MonadIO m
+     , MonadReader env m
+     , HasBugsnagSettings env
+     , Exception.Exception e
+     )
+  => BeforeNotify
+  -> e
+  -> m ()
+notifyBugsnagWith f ex = do
+  settings <- view bugsnagSettingsL
+  void $ liftIO $ forkIO $ Bugsnag.notifyBugsnagWith f settings ex
+
+asSqlError :: SqlError -> BeforeNotify
+asSqlError err@SqlError {..} = toSqlGrouping <> toSqlException
+ where
+  toSqlGrouping = maybe mempty setGroupingHash (sqlErrorGroupingHash err)
+  toSqlException = updateExceptions $ \ex -> ex
+    { exception_errorClass = decodeUtf8 $ "SqlError-" <> sqlState
+    , exception_message =
+      Just
+      $ decodeUtf8
+      $ sqlErrorMsg
+      <> ": "
+      <> sqlErrorDetail
+      <> " ("
+      <> sqlErrorHint
+      <> ")"
+    }
+
+sqlErrorGroupingHash :: SqlError -> Maybe Text
+sqlErrorGroupingHash err = do
+  violation <- constraintViolation err
+  decodeUtf8 <$> case violation of
+    ForeignKeyViolation table constraint -> pure $ table <> "." <> constraint
+    UniqueViolation constraint -> pure constraint
+    _ -> Nothing
+
+asHttpException :: HttpException -> BeforeNotify
+asHttpException (HttpExceptionRequest req content) =
+  setGroupingHash (decodeUtf8 $ host req) <> update
+ where
+  update = updateExceptions $ \ex -> ex
+    { exception_errorClass = "HttpExceptionRequest"
+    , exception_message =
+      Just
+      . decodeUtf8
+      $ method req
+      <> " request to "
+      <> host req
+      <> " failed: "
+      <> BS8.pack (show content)
+    }
+asHttpException (InvalidUrlException url msg) = updateExceptions $ \ex -> ex
+  { exception_errorClass = "InvalidUrlException"
+  , exception_message = Just $ pack $ url <> " is invalid: " <> msg
+  }
+
+-- | Set StackFrame's InProject to @'False'@ for Error Helper modules
+--
+-- We want exceptions grouped by the the first stack-frame that is /not/ them.
+-- Marking them as not in-project does this, with little downside.
+--
+maskErrorHelpers :: BeforeNotify
+maskErrorHelpers = setStackFramesInProjectByFile (`notElem` errorHelpers)
+  where errorHelpers = ["library/FrontRow/Core/Exceptions.hs"]
+
+-- brittany-disable-next-binding
+
+envParseBugsnagSettings :: Env.Parser Settings
+envParseBugsnagSettings =
+  build
+    <$> Env.var Env.str "BUGSNAG_API_KEY" Env.nonEmpty
+    <*> Env.var Env.str "BUGSNAG_RELEASE_STAGE" (Env.def "development")
+ where
+  build key stage = (defaultSettings key)
+    { settings_releaseStage = stage
+    , settings_beforeNotify = globalBeforeNotify
+    }
+
+globalBeforeNotify :: BeforeNotify
+globalBeforeNotify =
+  updateEventFromOriginalException asSqlError
+    <> updateEventFromOriginalException asHttpException
+    <> maskErrorHelpers

--- a/package.yaml
+++ b/package.yaml
@@ -56,6 +56,7 @@ library:
     - MonadRandom
     - aeson
     - ansi-terminal
+    - bugsnag
     - bytestring
     - case-insensitive
     - conduit
@@ -129,6 +130,7 @@ tests:
       - memcache
       - monad-logger
       - mtl
+      - postgresql-simple
       - unliftio-core
       - wai
       - wai-extra

--- a/stack-lts-12.26.yaml
+++ b/stack-lts-12.26.yaml
@@ -1,5 +1,7 @@
 resolver: lts-12.26
 extra-deps:
+  - bugsnag-1.0.0.1
+  - bugsnag-wai-1.0.0.1
   - hspec-2.8.1
   - hspec-core-2.8.1
   - hspec-discover-2.8.1

--- a/stack-lts-12.26.yaml
+++ b/stack-lts-12.26.yaml
@@ -1,5 +1,7 @@
 resolver: lts-12.26
 extra-deps:
+  - bugsnag-hs-0.2.0.8
+  - ua-parser-0.7.7.0
   - bugsnag-1.0.0.1
   - bugsnag-wai-1.0.0.1
   - hspec-2.8.1

--- a/stack-lts-12.26.yaml.lock
+++ b/stack-lts-12.26.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    pantry-tree:
+      size: 1527
+      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+  original:
+    hackage: bugsnag-1.0.0.1
+- completed:
+    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    pantry-tree:
+      size: 454
+      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+  original:
+    hackage: bugsnag-wai-1.0.0.1
+- completed:
     hackage: hspec-2.8.1@sha256:56ad90d6eff8b046aea6dbf87dd2518dc1b0c171acdfec785d02b26bdbbb1438,1709
     pantry-tree:
       size: 583

--- a/stack-lts-12.26.yaml.lock
+++ b/stack-lts-12.26.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: bugsnag-hs-0.2.0.8@sha256:978e699292a3910040f1525335284fb066c1c81f82130769df146c134dfecc64,1525
+    pantry-tree:
+      size: 456
+      sha256: b3959ee9116623e6a44a842521bd8a4396549d22c118d249d77ebc02c6ab8630
+  original:
+    hackage: bugsnag-hs-0.2.0.8
+- completed:
+    hackage: ua-parser-0.7.7.0@sha256:c79b871fe57109afe988c965fddfeaf21892afbe38b5644519d898768f742cb2,2651
+    pantry-tree:
+      size: 1390
+      sha256: 6f38f1c6aa6130c23847be326ab50bbdb257bd347c74b61ffc95981facf692f9
+  original:
+    hackage: ua-parser-0.7.7.0
+- completed:
     hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
     pantry-tree:
       size: 1527

--- a/stack-lts-14.27.yaml
+++ b/stack-lts-14.27.yaml
@@ -1,5 +1,7 @@
 resolver: lts-14.27
 extra-deps:
+  - bugsnag-1.0.0.1
+  - bugsnag-wai-1.0.0.1
   - hspec-2.8.1
   - hspec-core-2.8.1
   - hspec-discover-2.8.1

--- a/stack-lts-14.27.yaml
+++ b/stack-lts-14.27.yaml
@@ -1,7 +1,8 @@
 resolver: lts-14.27
 extra-deps:
-  - bugsnag-1.0.0.1
-  - bugsnag-wai-1.0.0.1
+  - bugsnag-1.0.0.0
+  - bugsnag-hs-0.2.0.8
+  - bugsnag-wai-1.0.0.0
   - hspec-2.8.1
   - hspec-core-2.8.1
   - hspec-discover-2.8.1

--- a/stack-lts-14.27.yaml.lock
+++ b/stack-lts-14.27.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    pantry-tree:
+      size: 1527
+      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+  original:
+    hackage: bugsnag-1.0.0.1
+- completed:
+    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    pantry-tree:
+      size: 454
+      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+  original:
+    hackage: bugsnag-wai-1.0.0.1
+- completed:
     hackage: hspec-2.8.1@sha256:56ad90d6eff8b046aea6dbf87dd2518dc1b0c171acdfec785d02b26bdbbb1438,1709
     pantry-tree:
       size: 583

--- a/stack-lts-14.27.yaml.lock
+++ b/stack-lts-14.27.yaml.lock
@@ -5,19 +5,26 @@
 
 packages:
 - completed:
-    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    hackage: bugsnag-1.0.0.0@sha256:0b5454bbf8527fc6e7f6fdbd4f21e0c1ce0387b690ee59175470d648f49a8cdc,4434
     pantry-tree:
       size: 1527
-      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+      sha256: 219c6dc7aa9f1f24c2d80994cff0a60c039480da48e04368fb7ea34283164f86
   original:
-    hackage: bugsnag-1.0.0.1
+    hackage: bugsnag-1.0.0.0
 - completed:
-    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    hackage: bugsnag-hs-0.2.0.8@sha256:978e699292a3910040f1525335284fb066c1c81f82130769df146c134dfecc64,1525
+    pantry-tree:
+      size: 456
+      sha256: b3959ee9116623e6a44a842521bd8a4396549d22c118d249d77ebc02c6ab8630
+  original:
+    hackage: bugsnag-hs-0.2.0.8
+- completed:
+    hackage: bugsnag-wai-1.0.0.0@sha256:ddac5c4fd3cf6b810de6d97459a7e84e4adedb31e01def748f16949e2768dccb,3196
     pantry-tree:
       size: 454
-      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+      sha256: 00ab354122f20c1daf46ad32e36fd10f5dbf3afdffa94a30241e1354f4941311
   original:
-    hackage: bugsnag-wai-1.0.0.1
+    hackage: bugsnag-wai-1.0.0.0
 - completed:
     hackage: hspec-2.8.1@sha256:56ad90d6eff8b046aea6dbf87dd2518dc1b0c171acdfec785d02b26bdbbb1438,1709
     pantry-tree:

--- a/stack-lts-16.31.yaml
+++ b/stack-lts-16.31.yaml
@@ -1,7 +1,8 @@
 resolver: lts-16.31
 extra-deps:
-  - bugsnag-1.0.0.1
-  - bugsnag-wai-1.0.0.1
+  - bugsnag-1.0.0.0
+  - bugsnag-hs-0.2.0.8
+  - bugsnag-wai-1.0.0.0
   - hspec-2.8.1
   - hspec-core-2.8.1
   - hspec-discover-2.8.1

--- a/stack-lts-16.31.yaml
+++ b/stack-lts-16.31.yaml
@@ -1,5 +1,7 @@
 resolver: lts-16.31
 extra-deps:
+  - bugsnag-1.0.0.1
+  - bugsnag-wai-1.0.0.1
   - hspec-2.8.1
   - hspec-core-2.8.1
   - hspec-discover-2.8.1

--- a/stack-lts-16.31.yaml.lock
+++ b/stack-lts-16.31.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    pantry-tree:
+      size: 1527
+      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+  original:
+    hackage: bugsnag-1.0.0.1
+- completed:
+    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    pantry-tree:
+      size: 454
+      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+  original:
+    hackage: bugsnag-wai-1.0.0.1
+- completed:
     hackage: hspec-2.8.1@sha256:56ad90d6eff8b046aea6dbf87dd2518dc1b0c171acdfec785d02b26bdbbb1438,1709
     pantry-tree:
       size: 583

--- a/stack-lts-16.31.yaml.lock
+++ b/stack-lts-16.31.yaml.lock
@@ -5,19 +5,26 @@
 
 packages:
 - completed:
-    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    hackage: bugsnag-1.0.0.0@sha256:0b5454bbf8527fc6e7f6fdbd4f21e0c1ce0387b690ee59175470d648f49a8cdc,4434
     pantry-tree:
       size: 1527
-      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+      sha256: 219c6dc7aa9f1f24c2d80994cff0a60c039480da48e04368fb7ea34283164f86
   original:
-    hackage: bugsnag-1.0.0.1
+    hackage: bugsnag-1.0.0.0
 - completed:
-    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    hackage: bugsnag-hs-0.2.0.8@sha256:978e699292a3910040f1525335284fb066c1c81f82130769df146c134dfecc64,1525
+    pantry-tree:
+      size: 456
+      sha256: b3959ee9116623e6a44a842521bd8a4396549d22c118d249d77ebc02c6ab8630
+  original:
+    hackage: bugsnag-hs-0.2.0.8
+- completed:
+    hackage: bugsnag-wai-1.0.0.0@sha256:ddac5c4fd3cf6b810de6d97459a7e84e4adedb31e01def748f16949e2768dccb,3196
     pantry-tree:
       size: 454
-      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+      sha256: 00ab354122f20c1daf46ad32e36fd10f5dbf3afdffa94a30241e1354f4941311
   original:
-    hackage: bugsnag-wai-1.0.0.1
+    hackage: bugsnag-wai-1.0.0.0
 - completed:
     hackage: hspec-2.8.1@sha256:56ad90d6eff8b046aea6dbf87dd2518dc1b0c171acdfec785d02b26bdbbb1438,1709
     pantry-tree:

--- a/stack-lts-18.28.yaml
+++ b/stack-lts-18.28.yaml
@@ -1,6 +1,8 @@
 resolver: lts-18.28
 
 extra-deps:
+  - bugsnag-1.0.0.1
+  - bugsnag-wai-1.0.0.1
   - hspec-2.9.3
   - hspec-core-2.9.3
   - hspec-discover-2.9.3

--- a/stack-lts-18.28.yaml
+++ b/stack-lts-18.28.yaml
@@ -1,8 +1,8 @@
 resolver: lts-18.28
 
 extra-deps:
-  - bugsnag-1.0.0.1
-  - bugsnag-wai-1.0.0.1
+  - bugsnag-1.0.0.0
+  - bugsnag-wai-1.0.0.0
   - hspec-2.9.3
   - hspec-core-2.9.3
   - hspec-discover-2.9.3

--- a/stack-lts-18.28.yaml.lock
+++ b/stack-lts-18.28.yaml.lock
@@ -5,19 +5,19 @@
 
 packages:
 - completed:
-    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    hackage: bugsnag-1.0.0.0@sha256:0b5454bbf8527fc6e7f6fdbd4f21e0c1ce0387b690ee59175470d648f49a8cdc,4434
     pantry-tree:
       size: 1527
-      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+      sha256: 219c6dc7aa9f1f24c2d80994cff0a60c039480da48e04368fb7ea34283164f86
   original:
-    hackage: bugsnag-1.0.0.1
+    hackage: bugsnag-1.0.0.0
 - completed:
-    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    hackage: bugsnag-wai-1.0.0.0@sha256:ddac5c4fd3cf6b810de6d97459a7e84e4adedb31e01def748f16949e2768dccb,3196
     pantry-tree:
       size: 454
-      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+      sha256: 00ab354122f20c1daf46ad32e36fd10f5dbf3afdffa94a30241e1354f4941311
   original:
-    hackage: bugsnag-wai-1.0.0.1
+    hackage: bugsnag-wai-1.0.0.0
 - completed:
     hackage: hspec-2.9.3@sha256:9b54d0c8ef8b3114aa39465a7b24658c987fbd6aab1479eafc00ee31da1be1de,1709
     pantry-tree:

--- a/stack-lts-18.28.yaml.lock
+++ b/stack-lts-18.28.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    pantry-tree:
+      size: 1527
+      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+  original:
+    hackage: bugsnag-1.0.0.1
+- completed:
+    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    pantry-tree:
+      size: 454
+      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+  original:
+    hackage: bugsnag-wai-1.0.0.1
+- completed:
     hackage: hspec-2.9.3@sha256:9b54d0c8ef8b3114aa39465a7b24658c987fbd6aab1479eafc00ee31da1be1de,1709
     pantry-tree:
       size: 583

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,7 +1,5 @@
-resolver: nightly-2022-03-30
+resolver: nightly-2022-05-23
 extra-deps:
-  - bugsnag-1.0.0.1
-  - bugsnag-wai-1.0.0.1
   - datadog-0.3.0.0
   - memcache-0.3.0.1
   - scientist-0.0.0.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,5 +1,7 @@
 resolver: nightly-2022-03-30
 extra-deps:
+  - bugsnag-1.0.0.1
+  - bugsnag-wai-1.0.0.1
   - datadog-0.3.0.0
   - memcache-0.3.0.1
   - scientist-0.0.0.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-05-23
+resolver: nightly-2022-05-20
 extra-deps:
   - datadog-0.3.0.0
   - memcache-0.3.0.1

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -38,7 +38,7 @@ packages:
     url: https://github.com/freckle/ekg-core/archive/43aac16a0ac762b5997a62d0fbae96242d54fe14.tar.gz
 snapshots:
 - completed:
-    size: 539378
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/3/30.yaml
-    sha256: 745431a4c5b78cc93d81e99b2253a1e0eacd4f94e00cf17dab7cc14e665332e3
-  original: nightly-2022-03-30
+    size: 588043
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/5/20.yaml
+    sha256: 7800e52de866bab899c118558f3a48e455f9f57fb3b3595e0002018fbea5ee58
+  original: nightly-2022-05-20

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
 resolver: lts-19.6
 
 extra-deps:
+  - bugsnag-1.0.0.1
+  - bugsnag-wai-1.0.0.1
   - hspec-junit-formatter-1.1.0.2
   - memcache-0.3.0.1
   - scientist-0.0.0.0
-  - bugsnag-1.0.0.1
-  - bugsnag-wai-1.0.0.1
   - github: freckle/ekg-core
     commit: 43aac16a0ac762b5997a62d0fbae96242d54fe14
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,8 @@ extra-deps:
   - hspec-junit-formatter-1.1.0.2
   - memcache-0.3.0.1
   - scientist-0.0.0.0
+  - bugsnag-1.0.0.1
+  - bugsnag-wai-1.0.0.1
   - github: freckle/ekg-core
     commit: 43aac16a0ac762b5997a62d0fbae96242d54fe14
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    pantry-tree:
+      size: 1527
+      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+  original:
+    hackage: bugsnag-1.0.0.1
+- completed:
+    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    pantry-tree:
+      size: 454
+      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+  original:
+    hackage: bugsnag-wai-1.0.0.1
+- completed:
     hackage: hspec-junit-formatter-1.1.0.2@sha256:9c30765a224e00d44686e47372f77415e54433823588a4a9637163c2750a1f5f,3825
     pantry-tree:
       size: 955
@@ -25,20 +39,6 @@ packages:
       sha256: 370ee941c6ce59486e5c27a1ce294e50ea47aa36a5bdd4f4eee0cd4834d8b763
   original:
     hackage: scientist-0.0.0.0
-- completed:
-    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
-    pantry-tree:
-      size: 1527
-      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
-  original:
-    hackage: bugsnag-1.0.0.1
-- completed:
-    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
-    pantry-tree:
-      size: 454
-      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
-  original:
-    hackage: bugsnag-wai-1.0.0.1
 - completed:
     size: 16090
     url: https://github.com/freckle/ekg-core/archive/43aac16a0ac762b5997a62d0fbae96242d54fe14.tar.gz

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,6 +26,20 @@ packages:
   original:
     hackage: scientist-0.0.0.0
 - completed:
+    hackage: bugsnag-1.0.0.1@sha256:a5b7afd9ff5bab322c1ce267ff0645afd7072071371462a0335f550609aa2546,4412
+    pantry-tree:
+      size: 1527
+      sha256: d76d9f0f1468a6ecf4bb7b7f5f74fc3819009a99d983dff7a8285cc27e1c34f1
+  original:
+    hackage: bugsnag-1.0.0.1
+- completed:
+    hackage: bugsnag-wai-1.0.0.1@sha256:6d9ed5cc2450bcb2150aec4825df1376d6930f9ed4e79b0e74d30379a226418a,3196
+    pantry-tree:
+      size: 454
+      sha256: c80a4c4e15eb2fd164fe430e4c1c420e62de42a1adaf415ac07befa8d0b36045
+  original:
+    hackage: bugsnag-wai-1.0.0.1
+- completed:
     size: 16090
     url: https://github.com/freckle/ekg-core/archive/43aac16a0ac762b5997a62d0fbae96242d54fe14.tar.gz
     name: ekg-core

--- a/tests/Freckle/App/BugsnagSpec.hs
+++ b/tests/Freckle/App/BugsnagSpec.hs
@@ -1,0 +1,135 @@
+module Freckle.App.BugsnagSpec
+  ( spec
+  ) where
+
+import Freckle.App.Prelude
+
+import Data.ByteString (ByteString)
+import Database.PostgreSQL.Simple (ExecStatus(..), SqlError(..))
+import Freckle.App.Bugsnag
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "sqlErrorGroupingHash" $ do
+    it "groups duplicate key errors by constraint name" $ do
+      let
+        err1 = sqlError
+          { sqlState = duplicateKeyState
+          , sqlErrorMsg = duplicateKeyErrorMsg "table_a_id_key"
+          , sqlErrorDetail = "Key (a, b)=(1, 2) already exists"
+          }
+        err2 = sqlError
+          { sqlState = duplicateKeyState
+          , sqlErrorMsg = duplicateKeyErrorMsg "table_a_id_key"
+          , sqlErrorDetail = "Key (a, b)=(3, 2) already exists"
+          }
+        err3 = sqlError
+          { sqlState = duplicateKeyState
+          , sqlErrorMsg = duplicateKeyErrorMsg "table_b_id_key"
+          , sqlErrorDetail = "Key (a, b)=(1, 2) already exists"
+          }
+
+      -- All duplicate keys hashed
+      sqlErrorGroupingHash err1 `shouldSatisfy` isJust
+      sqlErrorGroupingHash err2 `shouldSatisfy` isJust
+      sqlErrorGroupingHash err3 `shouldSatisfy` isJust
+
+      -- 1 and 2 are grouped, 3 is not (different constraint)
+      sqlErrorGroupingHash err1 `shouldBe` sqlErrorGroupingHash err2
+      sqlErrorGroupingHash err1 `shouldNotBe` sqlErrorGroupingHash err3
+      sqlErrorGroupingHash err2 `shouldNotBe` sqlErrorGroupingHash err3
+
+    it "groups foreign key errors by constraint name" $ do
+      let
+        err1 = sqlError
+          { sqlState = foreignKeyState
+          , sqlErrorMsg = foreignKeyErrorMsg "table_a" "table_b_id_fkey"
+          , sqlErrorDetail = "Key (a, b)=(1, 2) is still referenced"
+          }
+        err2 = sqlError
+          { sqlState = foreignKeyState
+          , sqlErrorMsg = foreignKeyErrorMsg "table_a" "table_b_id_fkey"
+          , sqlErrorDetail = "Key (a, b)=(3, 2) is still referenced"
+          }
+        err3 = sqlError
+          { sqlState = foreignKeyState
+          , sqlErrorMsg = foreignKeyErrorMsg "table_b" "table_b_id_key"
+          , sqlErrorDetail = "Key (a, b)=(1, 2) is still referenced"
+          }
+        err4 = sqlError
+          { sqlState = foreignKeyState
+          , sqlErrorMsg = foreignKeyErrorMsg "table_a" "table_a_id_key"
+          , sqlErrorDetail = "Key (a, b)=(1, 2) is still referenced"
+          }
+
+      -- All errors hashed
+      sqlErrorGroupingHash err1 `shouldSatisfy` isJust
+      sqlErrorGroupingHash err2 `shouldSatisfy` isJust
+      sqlErrorGroupingHash err3 `shouldSatisfy` isJust
+      sqlErrorGroupingHash err4 `shouldSatisfy` isJust
+
+      -- 1 and 2 are grouped, 3 and 4 are not (different table or constraint)
+      sqlErrorGroupingHash err1 `shouldBe` sqlErrorGroupingHash err2
+      sqlErrorGroupingHash err1 `shouldNotBe` sqlErrorGroupingHash err3
+      sqlErrorGroupingHash err2 `shouldNotBe` sqlErrorGroupingHash err3
+      sqlErrorGroupingHash err1 `shouldNotBe` sqlErrorGroupingHash err4
+      sqlErrorGroupingHash err2 `shouldNotBe` sqlErrorGroupingHash err4
+      sqlErrorGroupingHash err3 `shouldNotBe` sqlErrorGroupingHash err4
+
+    it "does not group other SqlErrors" $ do
+      let
+        err = sqlError
+          { sqlState = "9999"
+          , sqlErrorMsg = duplicateKeyErrorMsg "table_a_id_key"
+          , sqlErrorDetail = "Key (a, b)=(1, 2) already exists"
+          }
+
+      sqlErrorGroupingHash err `shouldBe` Nothing
+
+    it "does not group other states" $ do
+      let
+        err = sqlError
+          { sqlState = "12345"
+          , sqlErrorMsg = "State is wrong, \"table_a_id_key\""
+          , sqlErrorDetail = "Key (a, b)=(1, 2) already exists"
+          }
+
+      sqlErrorGroupingHash err `shouldBe` Nothing
+
+    it "does not group when unable to parse" $ do
+      let
+        err = sqlError
+          { sqlState = foreignKeyState
+          , sqlErrorMsg = "FK needs two quoted values, \"table_a_id_fkey\""
+          , sqlErrorDetail = "Key (a, b)=(1, 2) already exists"
+          }
+
+      sqlErrorGroupingHash err `shouldBe` Nothing
+
+sqlError :: SqlError
+sqlError = SqlError
+  { sqlState = ""
+  , sqlExecStatus = FatalError
+  , sqlErrorMsg = ""
+  , sqlErrorDetail = ""
+  , sqlErrorHint = ""
+  }
+
+duplicateKeyState :: ByteString
+duplicateKeyState = "23505"
+
+duplicateKeyErrorMsg :: ByteString -> ByteString
+duplicateKeyErrorMsg constraint =
+  "duplicate key value violates unique constraint \"" <> constraint <> "\""
+
+foreignKeyState :: ByteString
+foreignKeyState = "23503"
+
+foreignKeyErrorMsg :: ByteString -> ByteString -> ByteString
+foreignKeyErrorMsg table constraint =
+  "update or delete on table \""
+    <> table
+    <> "\" violates foreign key constraint \""
+    <> constraint
+    <> "\" on table \"unused\""


### PR DESCRIPTION
This commit includes a variety of Bugsnag supports for freckle apps.

- Parsing env variables.
- Refined grouping of common exceptions (http, sql).
- Standard `beforeNotify` hooks to add refinements.

These have been extracted from Freckle's applications with domain
specific logic removed.