### PR TITLE
Fix Test.Logging race condition

### DIFF
--- a/library/Freckle/App/Test/Logging.hs
+++ b/library/Freckle/App/Test/Logging.hs
@@ -5,9 +5,9 @@ module Freckle.App.Test.Logging
 import Freckle.App.Prelude
 
 import Control.Concurrent.Chan
-import Control.Monad (forever)
 import Control.Monad.Logger
 import UnliftIO.Async
+import UnliftIO.Exception (finally)
 import UnliftIO.IORef
 
 -- | Run a 'LoggingT', capturing and returning any logged messages alongside
@@ -19,12 +19,20 @@ runCapturedLoggingT :: MonadUnliftIO m => LoggingT m a -> m (a, [Text])
 runCapturedLoggingT f = do
   chan <- liftIO newChan
   ref <- newIORef []
-  x <- async $ forever $ do
-    (_, _, _, str) <- liftIO $ readChan chan
-    modifyIORef' ref (<> [decodeUtf8 $ fromLogStr str])
-
-  a <- runChanLoggingT chan f
-
-  cancel x
+  x <- async $ drainLog ref chan
+  a <- runChanLoggingT chan $ f `finally` logInfoN doneMessage
+  wait x
   msgs <- readIORef ref
   pure (a, msgs)
+
+drainLog :: MonadIO m => IORef [Text] -> Chan (a, b, c, LogStr) -> m ()
+drainLog ref chan = do
+  (_, _, _, str) <- liftIO $ readChan chan
+  let txt = decodeUtf8 $ fromLogStr str
+
+  unless (txt == doneMessage) $ do
+    modifyIORef' ref (<> [txt])
+    drainLog ref chan
+
+doneMessage :: Text
+doneMessage = "%DONE%"

--- a/library/Freckle/App/Test/Logging.hs
+++ b/library/Freckle/App/Test/Logging.hs
@@ -20,13 +20,13 @@ runCapturedLoggingT f = do
   x <- async $ captureLog [] chan
   a <- runChanLoggingT chan $ f `finally` logInfoN doneMessage
   msgs <- wait x
-  pure (a, msgs)
+  pure (a, reverse msgs)
 
 captureLog :: MonadIO m => [Text] -> Chan (a, b, c, LogStr) -> m [Text]
 captureLog acc chan = do
   (_, _, _, str) <- liftIO $ readChan chan
   let txt = decodeUtf8 $ fromLogStr str
-  if txt == doneMessage then pure acc else captureLog (acc <> [txt]) chan
+  if txt == doneMessage then pure acc else captureLog (txt : acc) chan
 
 doneMessage :: Text
 doneMessage = "%DONE%"


### PR DESCRIPTION
Occasionally the Memcacached spec fails because we don't see the final
log message. I traced this down to Test.Logging cancelling the
asynchronous loop reading them too eagerly.

This patch uses a sentinel final message so the draining loop will
always wait long enough and the test shouldn't flake.