### PR TITLE
Refactor runCapturedLoggingT

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -106,6 +106,7 @@ library
     , containers
     , data-default
     , datadog
+    , dlist
     , doctest
     , ekg-core
     , errors
@@ -294,7 +295,6 @@ test-suite spec
     , lens
     , lens-aeson
     , memcache
-    , monad-logger
     , mtl
     , postgresql-simple
     , unliftio-core

--- a/library/Freckle/App/Test/Logging.hs
+++ b/library/Freckle/App/Test/Logging.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Freckle.App.Test.Logging
   ( MonadLogger
   , LoggingT
@@ -13,6 +15,10 @@ import Data.DList (DList)
 import qualified Data.DList as DList
 import UnliftIO.Async
 import UnliftIO.Exception (finally)
+
+#if !MIN_VERSION_monad_logger(0,3,32)
+type LogLine = (Loc, LogSource, LogLevel, LogStr)
+#endif
 
 -- | Run a 'LoggingT', capturing and returning any logged messages alongside
 --

--- a/library/Freckle/App/Test/Logging.hs
+++ b/library/Freckle/App/Test/Logging.hs
@@ -1,32 +1,40 @@
 module Freckle.App.Test.Logging
-  ( runCapturedLoggingT
+  ( MonadLogger
+  , LoggingT
+  , runCapturedLoggingT
+  , logLineToText
   ) where
 
 import Freckle.App.Prelude
 
 import Control.Concurrent.Chan
 import Control.Monad.Logger
+import Data.DList (DList)
+import qualified Data.DList as DList
 import UnliftIO.Async
 import UnliftIO.Exception (finally)
 
 -- | Run a 'LoggingT', capturing and returning any logged messages alongside
 --
--- I do not know why 'runChanLoggingT' exists presumably for this purpose, but
--- requires so much more effort to ultimately accomplish.
+-- This is 'runWriterLoggingT', but we're not able to supply a 'MonadUnliftIO'
+-- instance when using that.
 --
-runCapturedLoggingT :: MonadUnliftIO m => LoggingT m a -> m (a, [Text])
+runCapturedLoggingT :: MonadUnliftIO m => LoggingT m a -> m (a, [LogLine])
 runCapturedLoggingT f = do
   chan <- liftIO newChan
-  x <- async $ captureLog [] chan
+  x <- async $ captureLog DList.empty chan
   a <- runChanLoggingT chan $ f `finally` logInfoN doneMessage
   msgs <- wait x
-  pure (a, reverse msgs)
+  pure (a, DList.toList msgs)
 
-captureLog :: MonadIO m => [Text] -> Chan (a, b, c, LogStr) -> m [Text]
+captureLog :: MonadIO m => DList LogLine -> Chan LogLine -> m (DList LogLine)
 captureLog acc chan = do
-  (_, _, _, str) <- liftIO $ readChan chan
-  let txt = decodeUtf8 $ fromLogStr str
-  if txt == doneMessage then pure acc else captureLog (txt : acc) chan
+  ll <- liftIO $ readChan chan
+  let txt = logLineToText ll
+  if txt == doneMessage then pure acc else captureLog (DList.snoc acc ll) chan
 
 doneMessage :: Text
 doneMessage = "%DONE%"
+
+logLineToText :: LogLine -> Text
+logLineToText (_, _, _, str) = decodeUtf8 $ fromLogStr str

--- a/package.yaml
+++ b/package.yaml
@@ -63,6 +63,7 @@ library:
     - containers
     - data-default
     - datadog
+    - dlist
     - doctest
     - ekg-core
     - errors
@@ -128,7 +129,6 @@ tests:
       - lens
       - lens-aeson
       - memcache
-      - monad-logger
       - mtl
       - postgresql-simple
       - unliftio-core

--- a/tests/Freckle/App/MemcachedSpec.hs
+++ b/tests/Freckle/App/MemcachedSpec.hs
@@ -5,7 +5,6 @@ module Freckle.App.MemcachedSpec
 import Freckle.App.Prelude
 
 import Control.Monad.IO.Unlift (MonadUnliftIO(..))
-import Control.Monad.Logger
 import Control.Monad.Reader
 import qualified Data.List.NonEmpty as NE
 import qualified Freckle.App.Env as Env
@@ -63,7 +62,9 @@ runTestAppT f = do
     "MEMCACHED_SERVERS"
     (Env.def defaultMemcachedServers)
   mc <- newMemcachedClient servers
-  runCapturedLoggingT $ runReaderT (unTestAppT f) mc
+  fmap (second $ map logLineToText) $ runCapturedLoggingT $ runReaderT
+    (unTestAppT f)
+    mc
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
- Make the interface `[LogLine]`, like [`runWriterLoggingT`][rwlt]
- Store messages in a `DList`, like `runWriterLoggingT` does
- Update comment to indicate why we can't just use `runWriterLoggingT`

[rwlt]: https://hackage.haskell.org/package/monad-logger-0.3.36/docs/Control-Monad-Logger.html#v:runWriterLoggingT
