### PR TITLE
Run Database pool creation in MonadLogger

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -136,7 +136,6 @@ library
     , persistent-postgresql
     , postgresql-simple
     , primitive
-    , process
     , resource-pool
     , retry >=0.8.1.0
     , rio
@@ -148,6 +147,7 @@ library
     , time
     , transformers
     , transformers-base
+    , typed-process
     , unliftio
     , unordered-containers
     , vector

--- a/library/Freckle/App/Ghci.hs
+++ b/library/Freckle/App/Ghci.hs
@@ -7,6 +7,7 @@ module Freckle.App.Ghci
 
 import Freckle.App.Prelude
 
+import Control.Monad.Logger (runNoLoggingT)
 import Database.Persist.Postgresql (runSqlPool)
 import Database.Persist.Sql (SqlBackend)
 import Freckle.App.Database (makePostgresPool)
@@ -19,7 +20,7 @@ runDB f = loadEnv *> runDB' f
 -- | Run a db action
 runDB' :: ReaderT SqlBackend IO b -> IO b
 runDB' f = do
-  pool <- makePostgresPool
+  pool <- runNoLoggingT makePostgresPool
   runSqlPool f pool
 
 loadEnvTest :: IO ()

--- a/package.yaml
+++ b/package.yaml
@@ -93,7 +93,6 @@ library:
     - persistent-postgresql
     - postgresql-simple
     - primitive
-    - process
     - resource-pool
     - retry >= 0.8.1.0
     - rio
@@ -105,6 +104,7 @@ library:
     - time
     - transformers
     - transformers-base
+    - typed-process
     - unliftio
     - unordered-containers
     - vector


### PR DESCRIPTION
This is how it is meant to work: creation of the pool captures the
logging context and will use it to log database activity. Doing this
allowed us to address some TODOs for logging token handling as well. I
also removed some TODOs that were _TODONE_ already, and some dead code.

To recover the previous behavior, end-users can import and use
`runNoLoggingT` themselves; but they are encouraged to use their real
logging context instead.
