### PR TITLE
Compatibility with envparse-0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.2.0.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.2.0.2...main)
+
+## [v1.2.0.2](https://github.com/freckle/freckle-app/compare/v1.2.0.1...v1.2.0.2)
+
+- `Env.kept` compatibility with envparse-0.5
 
 ## [v1.2.0.1](https://github.com/freckle/freckle-app/compare/v1.2.0.0...v1.2.0.1)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.2.0.1
+version:        1.2.0.2
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Env.hs
+++ b/library/Freckle/App/Env.hs
@@ -80,14 +80,14 @@ flag (Off f) (On t) n m = Env.flag f t n m
 
 -- | Modify a 'Parser' so variables are never removed after reading
 --
--- In @envparse-0.4@, read variables are removed from the environment. This is
--- often problematic (e.g. in tests that repeatedly load an app and re-read the
--- environment), and the security benefits are minor. This function will make
--- them all behave as if @keep@ was used.
+-- In @envparse-0.4@, read variables are removed from the environment by
+-- default. This is often problematic (e.g. in tests that repeatedly load an app
+-- and re-read the environment), and the security benefits are minor. This
+-- function will make them all behave as if @keep@ was used.
 --
 -- In @envparse-0.5@, the default is reversed and @sensitive@ can be used to
--- explicitly unset read variables. This function will make them all behave as
--- if @sensitive@ was /not/ used.
+-- explicitly unset read variables, and so this function will instead make them
+-- all behave as if @sensitive@ was /not/ used.
 --
 kept :: Parser e a -> Parser e a
 kept = Parser . hoistAlt go . unParser

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.2.0.1
+version: 1.2.0.2
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-06-06
+resolver: nightly-2022-06-14
 extra-deps:
   - Blammo-1.0.0.1
   - context-0.2.0.0

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -55,7 +55,7 @@ packages:
     hackage: scientist-0.0.0.0
 snapshots:
 - completed:
-    size: 605110
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/6/6.yaml
-    sha256: 26ea900ee8601fee24ff84981e92f304d384c73ee32d5504299133b5eb177e87
-  original: nightly-2022-06-06
+    size: 611629
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/6/14.yaml
+    sha256: 0053bc98eb1eae51d523de1ea060941285b4692e93d539b49e64429d50071fe4
+  original: nightly-2022-06-14


### PR DESCRIPTION
Immediately after implementing `kept`, [envparse-0.5](https://hackage.haskell.org/package/envparse-0.5.0) was released and
Stackage nightly picked it up. In order to stay, we need to be
compatible.

Should fix https://github.com/commercialhaskell/stackage/issues/6614