### PR TITLE
Extend Datadog tags functionality to simplify Apps

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -38,6 +38,7 @@ library
       Freckle.App.Datadog
       Freckle.App.Datadog.Gauge
       Freckle.App.Datadog.Rts
+      Freckle.App.Ecs
       Freckle.App.Env
       Freckle.App.Ghci
       Freckle.App.GlobalCache
@@ -108,6 +109,7 @@ library
     , envparse
     , errors
     , exceptions
+    , extra
     , filepath
     , hashable
     , hspec >=2.8.1

--- a/library/Freckle/App/Ecs.hs
+++ b/library/Freckle/App/Ecs.hs
@@ -1,0 +1,57 @@
+module Freckle.App.Ecs
+  ( EcsMetadata(..)
+  , EcsContainerMetadata(..)
+  , EcsContainerTaskMetadata(..)
+  , getEcsMetadata
+  ) where
+
+import Freckle.App.Prelude
+
+import Control.Error.Util (hush)
+import Data.Aeson
+import Data.List.Extra (dropPrefix)
+import Freckle.App.Http
+import System.Environment (lookupEnv)
+
+data EcsMetadata = EcsMetadata
+  { emContainerMetadata :: EcsContainerMetadata
+  , emContainerTaskMetadata :: EcsContainerTaskMetadata
+  }
+
+data EcsContainerMetadata = EcsContainerMetadata
+  { ecmDockerId :: Text
+  , ecmDockerName :: Text
+  , ecmImage :: Text
+  , ecmImageID :: Text
+  }
+  deriving stock Generic
+
+instance FromJSON EcsContainerMetadata where
+  parseJSON = genericParseJSON $ aesonDropPrefix "ecm"
+
+data EcsContainerTaskMetadata = EcsContainerTaskMetadata
+  { ectmCluster :: Text
+  , ectmTaskARN :: Text
+  , ectmFamily :: Text
+  , ectmRevision :: Text
+  }
+  deriving stock Generic
+
+instance FromJSON EcsContainerTaskMetadata where
+  parseJSON = genericParseJSON $ aesonDropPrefix "ectm"
+
+aesonDropPrefix :: String -> Options
+aesonDropPrefix x = defaultOptions { fieldLabelModifier = dropPrefix x }
+
+getEcsMetadata :: MonadIO m => m (Maybe EcsMetadata)
+getEcsMetadata =
+  liftA2 EcsMetadata
+    <$> makeContainerMetadataRequest "/"
+    <*> makeContainerMetadataRequest "/task"
+
+makeContainerMetadataRequest :: (MonadIO m, FromJSON a) => Text -> m (Maybe a)
+makeContainerMetadataRequest path = do
+  mURI <- liftIO $ lookupEnv "ECS_CONTAINER_METADATA_URI"
+  meMetadata <- for mURI $ \uri -> do
+    httpJson $ parseRequest_ $ uri <> unpack path
+  pure $ hush . getResponseBody =<< meMetadata

--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,7 @@ library:
     - envparse
     - errors
     - exceptions
+    - extra
     - filepath
     - hashable
     - hspec >= 2.8.1


### PR DESCRIPTION
This does three things:

- Look for `DD_{ENV,SERVICE,VERSION}` and add metric tags for them

  This will Just Work automatically for any users of
  `envParseDogStatsTags`. Apps will no longer need to copy the `DD_`
  variables into `DOGSTATSD_TAGS` explicitly in their `ENTRYPOINT`.

- Add `getEcsMetadataTags`

  Apps will need to call this and stash the values in their type to be
  part of the `HasDogStatsTags` instance. Once they do, they no longer
  need to fetch and copy these values into `DOGSTATSD_TAGS` in their
  `ENTRYPOINT` either.

  Between this and the point above, this should remove the need for
  custom `ENTRYPOINT`s in our Apps entirely.

- Add `withTagsAsThreadContext`

  Calling this in your main loop will unify the tags used for logs with
  those used for metrics by adding anything from `HasDogStatsTags` to
  the thread context.
