### PR TITLE
Use older primitive extra-dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.5.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.5.0.1...main)
+
+## [v1.5.0.1](https://github.com/freckle/freckle-app/compare/v1.5.0.0...v1.5.0.1)
+
+- Relax lower bound on `primitive`
 
 ## [v1.5.0.0](https://github.com/freckle/freckle-app/compare/v1.4.0.0...v1.5.0.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.5.0.0
+version:        1.5.0.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.5.0.0
+version: 1.5.0.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app

--- a/stack-lts-12.26.yaml
+++ b/stack-lts-12.26.yaml
@@ -54,7 +54,7 @@ extra-deps:
   - assoc-1
   - base-orphans-0.8.1
   - context-0.2.0.1
-  - primitive-0.7.4.0
+  - primitive-0.7.0.1
   - splitmix-0.0.2
   - tagged-0.8.6
   - these-1.1

--- a/stack-lts-12.26.yaml.lock
+++ b/stack-lts-12.26.yaml.lock
@@ -250,12 +250,12 @@ packages:
   original:
     hackage: context-0.2.0.1
 - completed:
-    hackage: primitive-0.7.4.0@sha256:89b88a3e08493b7727fa4089b0692bfbdf7e1e666ef54635f458644eb8358764,2857
+    hackage: primitive-0.7.0.1@sha256:a381571c36edc7dca28b77fe8159b43c14c640087ec5946adacf949feec64231,3433
     pantry-tree:
-      size: 1655
-      sha256: 71a850c658b70e869da19f61615d87d9d6ecec597f0e3d4b498da56559114829
+      size: 3221
+      sha256: fea4312bd404ad504e44a7fd933a3b3442c0a5e1c41bd8abec3c2e7282d88e18
   original:
-    hackage: primitive-0.7.4.0
+    hackage: primitive-0.7.0.1
 - completed:
     hackage: splitmix-0.0.2@sha256:e1c4d1202757d63cd4b4498d5fa600a792f2a315d2fdc6cf772f4679113c1819,3298
     pantry-tree:

--- a/stack-lts-14.27.yaml
+++ b/stack-lts-14.27.yaml
@@ -28,5 +28,5 @@ extra-deps:
   # See https://github.com/jship/monad-logger-aeson/blob/main/stack-lts-14.yaml
   - aeson-1.5.2.0
   - context-0.2.0.1
-  - primitive-0.7.4.0
+  - primitive-0.7.0.1
   - these-1.1

--- a/stack-lts-14.27.yaml.lock
+++ b/stack-lts-14.27.yaml.lock
@@ -138,12 +138,12 @@ packages:
   original:
     hackage: context-0.2.0.1
 - completed:
-    hackage: primitive-0.7.4.0@sha256:89b88a3e08493b7727fa4089b0692bfbdf7e1e666ef54635f458644eb8358764,2857
+    hackage: primitive-0.7.0.1@sha256:a381571c36edc7dca28b77fe8159b43c14c640087ec5946adacf949feec64231,3433
     pantry-tree:
-      size: 1655
-      sha256: 71a850c658b70e869da19f61615d87d9d6ecec597f0e3d4b498da56559114829
+      size: 3221
+      sha256: fea4312bd404ad504e44a7fd933a3b3442c0a5e1c41bd8abec3c2e7282d88e18
   original:
-    hackage: primitive-0.7.4.0
+    hackage: primitive-0.7.0.1
 - completed:
     hackage: these-1.1@sha256:18ff38deaaf314cec509f9bd41c2a7a2a6b64210846eed89976173534b5bccb6,2650
     pantry-tree:


### PR DESCRIPTION
When I added this, I mistakenly used the latest primitive (0.7.4.0) and
not the minimum as required by aeson (0.7.0.1). This is particularly
problematic because our oldest snapshot sets our lower bounds on
release, so we ended up shipping with a very high lower-bound on
primitive and we're being held out of Stackage because of it.