### PR TITLE
Export tagsL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.5.0.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.5.1.0...main)
+
+## [v1.5.0.1](https://github.com/freckle/freckle-app/compare/v1.5.0.1...v1.5.1.0)
+
+- Export `Freckle.App.Stats.tagsL`
 
 ## [v1.5.0.1](https://github.com/freckle/freckle-app/compare/v1.5.0.0...v1.5.0.1)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.5.0.1
+version:        1.5.1.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Stats.hs
+++ b/library/Freckle/App/Stats.hs
@@ -10,6 +10,7 @@ module Freckle.App.Stats
 
   -- * Client
   , StatsClient
+  , tagsL
   , withStatsClient
   , HasStatsClient(..)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.5.0.1
+version: 1.5.1.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
The automatic adding of tags to the thread context doesn't work for a
web application that forks a new thread (with an empty context) for
every request.

This can be solved pretty easily by setting up the context yourself in a
WAI middleware, but it requires pulling the tags off of the app type,
and so we need a function to access them.

The existing Lens function maintains encapsulation and
composes well with `statsClientL`:

```hs
statsTags :: HasStatsClient env => env -> [(Text, Text)]
statsTags = app ^.. statsClientL . tagsL . traverse
```

This can be used with a Middleware like `addThreadContext` from Blammo.
