### PR TITLE
Group SqlError Timeouts by Request URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.6.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.6.0.1...main)
+
+## [v1.6.0.1](https://github.com/freckle/freckle-app/compare/v1.6.0.0...v1.6.0.1)
+
+- The built-in Bugsnag `BeforeNotify` will further group `SqlError`s that are
+  timeouts (57014) by Request URL (when request info is present in the `Event`)
 
 ## [v1.6.0.0](https://github.com/freckle/freckle-app/compare/v1.5.0.1...v1.6.0.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.6.0.0
+version:        1.6.0.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.6.0.0
+version: 1.6.0.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
A timeout can happen basically anywhere, so having them all grouped
together is not useful for triaging. Segregating them at least by
Request URL would be an improvement for us. Note that if the Request or
URL is missing, we fall back to grouping them all together. This means
you should ensure the `updateEventFromWaiRequest` `BeforeNotify` runs
before this one.
