### PR TITLE
Drop query string from URL used to group timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.6.0.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.6.0.2...main)
+
+## [v1.6.0.2](https://github.com/freckle/freckle-app/compare/v1.6.0.1...v1.6.0.2)
+
+- Strip query string from URLs used to group timeout exceptions in Bugsnag.
 
 ## [v1.6.0.1](https://github.com/freckle/freckle-app/compare/v1.6.0.0...v1.6.0.1)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.6.0.1
+version:        1.6.0.2
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -29,6 +29,7 @@ import Data.Bugsnag
 import Data.Bugsnag.Settings
 import qualified Data.ByteString.Char8 as BS8
 import Data.List (isInfixOf)
+import qualified Data.Text as T
 import Database.PostgreSQL.Simple (SqlError(..))
 import Database.PostgreSQL.Simple.Errors
 import qualified Freckle.App.Env as Env
@@ -113,7 +114,7 @@ groupTimeoutByRequestUrl SqlError {..} event = do
   guard $ sqlState == "57014"
   req <- event_request event
   url <- request_url req
-  pure $ "SQL-Timeout-In-" <> url
+  pure $ "SQL-Timeout-In-" <> T.takeWhile (/= '?') url
 
 sqlErrorGroupingHash :: SqlError -> Maybe Text
 sqlErrorGroupingHash err = do

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.6.0.1
+version: 1.6.0.2
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
Query strings will vary from call to call, especially because we include
an `echo` GET param that is unique to every request. This means we'd be
effectively making unique timeout Errors every time.

Naively stripping the query string works (vs parsing the URL), since
we're not using this for anything critical, and will ensure this groups
by domain-path only. Hashes should not be involved for a Backend API,
though we could strip that too if we find cases.
