### PR TITLE
Revert regrouping of SqlError by url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.6.0.2...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.6.0.3...main)
+
+## [v1.6.0.3](https://github.com/freckle/freckle-app/compare/v1.6.0.2...v1.6.0.3)
+
+- Revert regrouping of `SqlError` by `url`
+
+  Consider `/foos/1` vs `/foos/2`: grouping naively by `url` makes these two
+  errors when we wanted them to be one. This can't be solved without knowledge
+  of the routing system, so we can't do it from within this library as-is.
+  Therefore, we've reverted the feature for now.
 
 ## [v1.6.0.2](https://github.com/freckle/freckle-app/compare/v1.6.0.1...v1.6.0.2)
 

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -90,11 +90,9 @@ notifyBugsnagWith f ex = do
   void $ liftIO $ forkIO $ Bugsnag.notifyBugsnagWith f settings ex
 
 asSqlError :: SqlError -> BeforeNotify
-asSqlError err@SqlError {..} =
-  setGroupingHashBy (groupTimeoutByRequestUrl err)
-    <> setGroupingHashBy (const $ sqlErrorGroupingHash err)
-    <> toSqlException
+asSqlError err@SqlError {..} = toSqlGrouping <> toSqlException
  where
+  toSqlGrouping = maybe mempty setGroupingHash (sqlErrorGroupingHash err)
   toSqlException = updateExceptions $ \ex -> ex
     { exception_errorClass = decodeUtf8 $ "SqlError-" <> sqlState
     , exception_message =
@@ -107,13 +105,6 @@ asSqlError err@SqlError {..} =
       <> sqlErrorHint
       <> ")"
     }
-
-groupTimeoutByRequestUrl :: SqlError -> Event -> Maybe Text
-groupTimeoutByRequestUrl SqlError {..} event = do
-  guard $ sqlState == "57014"
-  req <- event_request event
-  url <- request_url req
-  pure $ "SQL-Timeout-In-" <> url
 
 sqlErrorGroupingHash :: SqlError -> Maybe Text
 sqlErrorGroupingHash err = do

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -29,7 +29,6 @@ import Data.Bugsnag
 import Data.Bugsnag.Settings
 import qualified Data.ByteString.Char8 as BS8
 import Data.List (isInfixOf)
-import qualified Data.Text as T
 import Database.PostgreSQL.Simple (SqlError(..))
 import Database.PostgreSQL.Simple.Errors
 import qualified Freckle.App.Env as Env
@@ -114,7 +113,7 @@ groupTimeoutByRequestUrl SqlError {..} event = do
   guard $ sqlState == "57014"
   req <- event_request event
   url <- request_url req
-  pure $ "SQL-Timeout-In-" <> T.takeWhile (/= '?') url
+  pure $ "SQL-Timeout-In-" <> url
 
 sqlErrorGroupingHash :: SqlError -> Maybe Text
 sqlErrorGroupingHash err = do

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.6.0.2
+version: 1.6.0.3
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
The CHANGELOG says it best:

Consider `/foos/1` vs `/foos/2`: grouping naively by `url` makes these two
errors when we wanted them to be one. This can't be solved without knowledge
of the routing system, so we can't do it from within this library as-is.
Therefore, we've reverted the feature for now.