### PR TITLE
Add runDBSimple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.8.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.8.1.0...main)
 
 ## [v1.8.1.0](https://github.com/freckle/freckle-app/compare/v1.8.0.0...v1.8.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.8.0.0...main)
 
+## [v1.8.1.0](https://github.com/freckle/freckle-app/compare/v1.8.0.0...v1.8.1.0)
+
+- Add `runDBSimple` for use cases where instrumentation is not valuable.
+
 ## [v1.8.0.0](https://github.com/freckle/freckle-app/compare/v1.7.1.0...v1.8.0.0)
 
 - Fix bug: gauges not being published.

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.8.0.0
+version:        1.8.1.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -100,7 +100,7 @@ runDB action = do
       action
       pool
 
-runDBSimple 
+runDBSimple
   :: ( HasSqlPool app
      , MonadUnliftIO m
      , MonadReader app m

--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -13,6 +13,7 @@ module Freckle.App.Database
   , makePostgresPool
   , makePostgresPoolWith
   , runDB
+  , runDBSimple
   , PostgresConnectionConf(..)
   , PostgresPasswordSource(..)
   , PostgresPassword(..)
@@ -98,6 +99,17 @@ runDB action = do
       mVaultData
       action
       pool
+
+runDBSimple 
+  :: ( HasSqlPool app
+     , MonadUnliftIO m
+     , MonadReader app m
+     )
+  => SqlPersistT m a
+  -> m a
+runDBSimple action = do
+  pool <- asks getSqlPool
+  runSqlPool action pool
 
 -- | @'runSqlPool'@ but with XRay tracing
 runSqlPoolXRay

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: freckle-app
-version: 1.8.0.0
+version: 1.8.1.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
Implement a version of `runDB` that doesn't do instrumentation so that `TestImport` and other users where instrumentation isn't appropriate do not have to fulfill the contract of `runDB`.