### PR TITLE
Add Freckle.App.OpenTelemetry

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -47,6 +47,7 @@ library
       Freckle.App.Memcached.CacheTTL
       Freckle.App.Memcached.Client
       Freckle.App.Memcached.Servers
+      Freckle.App.OpenTelemetry
       Freckle.App.Prelude
       Freckle.App.Scientist
       Freckle.App.Stats
@@ -117,6 +118,9 @@ library
     , extra
     , filepath
     , hashable
+    , hs-opentelemetry-awsxray
+    , hs-opentelemetry-instrumentation-persistent
+    , hs-opentelemetry-sdk
     , hspec >=2.8.1
     , hspec-core >=2.8.1
     , hspec-expectations-lifted

--- a/library/Freckle/App.hs
+++ b/library/Freckle/App.hs
@@ -150,11 +150,13 @@ module Freckle.App
 import Freckle.App.Prelude
 
 import Blammo.Logging as X
+import Control.Lens (view)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Control.Monad.Reader as X
 import Control.Monad.Trans.Resource (MonadResource, ResourceT, runResourceT)
 import Freckle.App.Database as X
+import Freckle.App.OpenTelemetry as X
 import System.IO (BufferMode(..), hSetBuffering, stderr, stdout)
 
 runApp
@@ -196,6 +198,9 @@ newtype AppT app m a = AppT
 instance MonadUnliftIO m => MonadUnliftIO (AppT app m) where
   {-# INLINE withRunInIO #-}
   withRunInIO inner = AppT $ withRunInIO $ \run -> inner $ run . unAppT
+
+instance (Monad m, HasTracer app) => MonadTracer (AppT app m) where
+  getTracer = view tracerL
 
 runAppT :: (MonadUnliftIO m, HasLogger app) => AppT app m a -> app -> m a
 runAppT action app =

--- a/library/Freckle/App/Memcached/CacheKey.hs
+++ b/library/Freckle/App/Memcached/CacheKey.hs
@@ -10,7 +10,6 @@ import Freckle.App.Prelude
 import Data.Char (isControl, isSpace)
 import qualified Data.Text as T
 import Database.Memcache.Types (Key)
-import GHC.Stack (HasCallStack)
 import UnliftIO.Exception (throwString)
 
 newtype CacheKey = CacheKey Text

--- a/library/Freckle/App/OpenTelemetry.hs
+++ b/library/Freckle/App/OpenTelemetry.hs
@@ -1,0 +1,41 @@
+module Freckle.App.OpenTelemetry
+  ( HasTracer(..)
+  , MonadTracer(..)
+  , inSpan
+  , withTracerProviderXRay
+  , withTracerProviderDisabled
+  ) where
+
+import Freckle.App.Prelude
+
+import Control.Lens ((.~), (<>~))
+import OpenTelemetry.AWSXRay
+import OpenTelemetry.Trace
+  ( HasTracer(..)
+  , TracerProvider
+  , defaultSpanArguments
+  , emptyTracerProviderOptions
+  )
+import OpenTelemetry.Trace.Monad (MonadTracer(..))
+import qualified OpenTelemetry.Trace.Monad as Trace
+import qualified OpenTelemetry.Trace.Setup as Trace
+import OpenTelemetry.Trace.Setup.Lens
+
+inSpan :: (MonadUnliftIO m, MonadTracer m, HasCallStack) => Text -> m a -> m a
+inSpan = flip Trace.inSpan defaultSpanArguments
+
+-- | Configure tracing with Id values compatible with AWS X-Ray
+withTracerProviderXRay :: MonadUnliftIO m => (TracerProvider -> m a) -> m a
+withTracerProviderXRay =
+  Trace.withTracerProvider
+    $ (idGeneratorL .~ awsXRayIdGenerator)
+    . (propagatorL <>~ awsXRayContextPropagator)
+
+-- | Configure no tracing
+--
+-- This allows you to still make and set a 'Tracer' and satisfy 'MonadTracer',
+-- but not actually emit any traces.
+--
+withTracerProviderDisabled :: MonadUnliftIO m => (TracerProvider -> m a) -> m a
+withTracerProviderDisabled =
+  Trace.withTracerProvider $ const emptyTracerProviderOptions

--- a/library/Freckle/App/Prelude.hs
+++ b/library/Freckle/App/Prelude.hs
@@ -1,13 +1,12 @@
 -- | Those functions and types we can't do without!
 module Freckle.App.Prelude
-  (
-  -- * 'Prelude' as the starting point, without common partial functions
-    module Prelude
+  ( module Prelude
 
   -- * Commonly imported types
   , Alternative
   , Exception
   , Generic
+  , HasCallStack
   , HashMap
   , HashSet
   , Hashable
@@ -100,9 +99,9 @@ import Control.Applicative (Alternative, liftA2, optional, (<|>))
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Primitive (PrimMonad)
 import Control.Monad.Reader (MonadReader, ReaderT)
+import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
-import Data.Hashable (Hashable)
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
@@ -111,6 +110,7 @@ import Data.Text (Text, pack, unpack)
 import Data.Time (NominalDiffTime, UTCTime, getCurrentTime)
 import Data.Vector (Vector)
 import GHC.Generics (Generic)
+import GHC.Stack (HasCallStack)
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception (Exception)
 

--- a/package.yaml
+++ b/package.yaml
@@ -90,6 +90,9 @@ library:
     - extra
     - filepath
     - hashable
+    - hs-opentelemetry-awsxray
+    - hs-opentelemetry-instrumentation-persistent
+    - hs-opentelemetry-sdk
     - hspec >= 2.8.1
     - hspec-core >= 2.8.1
     - hspec-expectations-lifted

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,17 @@
 resolver: lts-20.12
 extra-deps:
   - monad-validate-1.2.0.1
+
+  # For OTel
+  - github: freckle/hs-opentelemetry-awsxray
+    commit: 1189301f706cf5dfd519f04715f50f604d6f03b5
+  - hs-opentelemetry-api-0.0.3.6
+  - hs-opentelemetry-exporter-otlp-0.0.1.4
+  - hs-opentelemetry-instrumentation-persistent-0.0.1.0
+  - hs-opentelemetry-instrumentation-wai-0.0.1.3
+  - hs-opentelemetry-instrumentation-yesod-0.0.1.3
+  - hs-opentelemetry-otlp-0.0.1.0
+  - hs-opentelemetry-propagator-w3c-0.0.1.2
+  - hs-opentelemetry-sdk-0.0.3.4
+  - thread-utils-context-0.2.0.0
+  - thread-utils-finalizers-0.1.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,87 @@ packages:
       size: 611
   original:
     hackage: monad-validate-1.2.0.1
+- completed:
+    name: hs-opentelemetry-awsxray
+    pantry-tree:
+      sha256: 303a9154b10261e04dca4084d615a2ba15d83eace1854bb9362427daa778230d
+      size: 2234
+    sha256: 00fb4454006ed4c85bb8fa2d73f072f60415611e981ad9454efe77406db0ee78
+    size: 13290
+    url: https://github.com/freckle/hs-opentelemetry-awsxray/archive/1189301f706cf5dfd519f04715f50f604d6f03b5.tar.gz
+    version: 0.0.0.0
+  original:
+    url: https://github.com/freckle/hs-opentelemetry-awsxray/archive/1189301f706cf5dfd519f04715f50f604d6f03b5.tar.gz
+- completed:
+    hackage: hs-opentelemetry-api-0.0.3.6@sha256:76345dca8efda3040f58e85fa8b17264505177928bd035936132448715437a7c,3428
+    pantry-tree:
+      sha256: 6bcb617406e61a2fa68ebc313fad675671ac8acb57a144da41201fa1a75cdaa3
+      size: 2907
+  original:
+    hackage: hs-opentelemetry-api-0.0.3.6
+- completed:
+    hackage: hs-opentelemetry-exporter-otlp-0.0.1.4@sha256:25fcf5c2173f1dd3fe4f288f3232da70e9d8398363430932b7e2a278f78c3765,2150
+    pantry-tree:
+      sha256: 6d2ae7125938614e10d01b317d10bfd4575bb62889360c4476dda2b904766cda
+      size: 400
+  original:
+    hackage: hs-opentelemetry-exporter-otlp-0.0.1.4
+- completed:
+    hackage: hs-opentelemetry-instrumentation-persistent-0.0.1.0@sha256:5963e5bf98ccf73543955ebd523c2a4776f7e6a2edf0feabbc44664153662caf,1669
+    pantry-tree:
+      sha256: 0cf9da228de66c804c8f945cc90301aa76b85d872011afb0bcaf02569c7b0903
+      size: 424
+  original:
+    hackage: hs-opentelemetry-instrumentation-persistent-0.0.1.0
+- completed:
+    hackage: hs-opentelemetry-instrumentation-wai-0.0.1.3@sha256:417c714052ee94b8b6a7f2b303ee92908c232f6d44a1a1c6232acf17434be753,1767
+    pantry-tree:
+      sha256: c1fa4fee66d3cb299276e2a32d1d027ac26ab9a354665e7bc95f6e163922194d
+      size: 411
+  original:
+    hackage: hs-opentelemetry-instrumentation-wai-0.0.1.3
+- completed:
+    hackage: hs-opentelemetry-instrumentation-yesod-0.0.1.3@sha256:e6e6923e3d320aba4d84997a41c628507cb754e4370b1fcf727b8b337908769c,1913
+    pantry-tree:
+      sha256: dcb06cc670aec9056905a9ae5cb77391183cd12c886dcf1db778818ba65fd79d
+      size: 415
+  original:
+    hackage: hs-opentelemetry-instrumentation-yesod-0.0.1.3
+- completed:
+    hackage: hs-opentelemetry-otlp-0.0.1.0@sha256:88bb6b68f172a336f78018b0823f47363fb7408eb19f7301489f81ad4d5c0f33,2307
+    pantry-tree:
+      sha256: e56292fc693805babed3c7ba7fc54e59d2e9adbc38de6bcc659009e8b10b9a1b
+      size: 2252
+  original:
+    hackage: hs-opentelemetry-otlp-0.0.1.0
+- completed:
+    hackage: hs-opentelemetry-propagator-w3c-0.0.1.2@sha256:ba1e33ff73bec76ec53b049b0cb3d1a65a6849a60c0da08bbef308f0edc241d1,1751
+    pantry-tree:
+      sha256: 3f3a81317fe511bf11191d6ea186d7c98c7fd794b32cc358606ee681637b2a0e
+      size: 496
+  original:
+    hackage: hs-opentelemetry-propagator-w3c-0.0.1.2
+- completed:
+    hackage: hs-opentelemetry-sdk-0.0.3.4@sha256:b33cb9e705ea3c591df324976d47ae2b11087af6a0533221840cec2a929db331,3638
+    pantry-tree:
+      sha256: 7445b1dbd5c88677567712bb9cc4e2caa9ef3923662a2afcbad959c22c9b295e
+      size: 1430
+  original:
+    hackage: hs-opentelemetry-sdk-0.0.3.4
+- completed:
+    hackage: thread-utils-context-0.2.0.0@sha256:7863e568c7a43cd21616342d20484d4c962aaa9710619f104c6fb7ee32273940,1883
+    pantry-tree:
+      sha256: 605ea068880ad39c96fce0d91db9f2d54553ed43dfc41c37845fade8be2e9568
+      size: 450
+  original:
+    hackage: thread-utils-context-0.2.0.0
+- completed:
+    hackage: thread-utils-finalizers-0.1.0.0@sha256:a8435240bfc0ae96c94704d2986699a11a395c496f9a7f2e5f5d729a0b967549,1381
+    pantry-tree:
+      sha256: 7f708d158d5d0e32ffe77f6375a792ceb6f92e4d8dd8b32fc69e7de962e7e518
+      size: 400
+  original:
+    hackage: thread-utils-finalizers-0.1.0.0
 snapshots:
 - completed:
     sha256: af5d667f6096e535b9c725a72cffe0f6c060e0568d9f9eeda04caee70d0d9d2d


### PR DESCRIPTION
And update `runDB` to use it.

A `runDBXRay` is preserved in the (unlikely) event one of our apps needs
to update but cannot satisfy `MonadTracer`. To use it requires silencing
the deprecation warning, which is intentional.
