### PR TITLE
Address some OTel omissions

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -92,7 +92,7 @@ library
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fignore-optim-changes -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-unsafe -Wno-safe
+  ghc-options: -fignore-optim-changes -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe
   build-depends:
       Blammo
     , Glob
@@ -202,7 +202,7 @@ test-suite doctest
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fignore-optim-changes -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-unsafe -Wno-safe
+  ghc-options: -fignore-optim-changes -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe
   build-depends:
       base <5
     , freckle-app
@@ -256,7 +256,7 @@ test-suite spec
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fignore-optim-changes -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-unsafe -Wno-safe -threaded -rtsopts "-with-rtsopts=-N"
+  ghc-options: -fignore-optim-changes -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe -threaded -rtsopts "-with-rtsopts=-N"
   build-depends:
       Blammo
     , QuickCheck

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -48,6 +48,7 @@ library
       Freckle.App.Memcached.Client
       Freckle.App.Memcached.Servers
       Freckle.App.OpenTelemetry
+      Freckle.App.OpenTelemetry.Wai
       Freckle.App.Prelude
       Freckle.App.Scientist
       Freckle.App.Stats
@@ -121,6 +122,7 @@ library
     , hs-opentelemetry-api
     , hs-opentelemetry-awsxray
     , hs-opentelemetry-instrumentation-persistent
+    , hs-opentelemetry-instrumentation-wai
     , hs-opentelemetry-sdk
     , hspec >=2.8.1
     , hspec-core >=2.8.1

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -118,6 +118,7 @@ library
     , extra
     , filepath
     , hashable
+    , hs-opentelemetry-api
     , hs-opentelemetry-awsxray
     , hs-opentelemetry-instrumentation-persistent
     , hs-opentelemetry-sdk

--- a/library/Freckle/App/OpenTelemetry.hs
+++ b/library/Freckle/App/OpenTelemetry.hs
@@ -1,24 +1,48 @@
 module Freckle.App.OpenTelemetry
   ( HasTracer(..)
+  , Tracer
+
+  -- * Effects
   , MonadTracer(..)
   , inSpan
+
+  -- * Setup
+  -- ** Built-ins
   , withTracerProviderXRay
+  , withTracerProviderXRayLogger
   , withTracerProviderDisabled
+
+  -- ** Combinatorially
+  , withTracerProvider
+  , setupAWSXRay
+  , setupLogger
+  , disableTracing
+
+  -- ** 'Tracer'
+  , makeTracer
+  , tracerOptions
   ) where
 
 import Freckle.App.Prelude
 
+import Blammo.Logging
+  (LogLevel(..), Logger, Message(..), logOtherNS, runLoggerLoggingT)
 import Control.Lens ((.~), (<>~))
 import OpenTelemetry.AWSXRay
+import qualified OpenTelemetry.Logging.Core as Trace
 import OpenTelemetry.Trace
   ( HasTracer(..)
+  , Tracer
   , TracerProvider
+  , TracerProviderOptions
   , defaultSpanArguments
   , emptyTracerProviderOptions
+  , makeTracer
+  , tracerOptions
   )
 import OpenTelemetry.Trace.Monad (MonadTracer(..))
 import qualified OpenTelemetry.Trace.Monad as Trace
-import qualified OpenTelemetry.Trace.Setup as Trace
+import OpenTelemetry.Trace.Setup
 import OpenTelemetry.Trace.Setup.Lens
 
 inSpan :: (MonadUnliftIO m, MonadTracer m, HasCallStack) => Text -> m a -> m a
@@ -26,10 +50,13 @@ inSpan = flip Trace.inSpan defaultSpanArguments
 
 -- | Configure tracing with Id values compatible with AWS X-Ray
 withTracerProviderXRay :: MonadUnliftIO m => (TracerProvider -> m a) -> m a
-withTracerProviderXRay =
-  Trace.withTracerProvider
-    $ (idGeneratorL .~ awsXRayIdGenerator)
-    . (propagatorL <>~ awsXRayContextPropagator)
+withTracerProviderXRay = withTracerProvider setupAWSXRay
+
+-- | 'withTracerProviderXRay' but also configure to log via 'Logger'
+withTracerProviderXRayLogger
+  :: MonadUnliftIO m => Logger -> (TracerProvider -> m a) -> m a
+withTracerProviderXRayLogger logger =
+  withTracerProvider $ setupAWSXRay . setupLogger logger
 
 -- | Configure no tracing
 --
@@ -37,5 +64,36 @@ withTracerProviderXRay =
 -- but not actually emit any traces.
 --
 withTracerProviderDisabled :: MonadUnliftIO m => (TracerProvider -> m a) -> m a
-withTracerProviderDisabled =
-  Trace.withTracerProvider $ const emptyTracerProviderOptions
+withTracerProviderDisabled = withTracerProvider disableTracing
+
+setupAWSXRay :: TracerProviderOptions -> TracerProviderOptions
+setupAWSXRay =
+  (idGeneratorL .~ awsXRayIdGenerator)
+    . (propagatorL <>~ awsXRayContextPropagator)
+
+setupLogger :: Logger -> (TracerProviderOptions -> TracerProviderOptions)
+setupLogger logger = loggerL .~ go
+ where
+  go l = runLoggerLoggingT logger $ do
+    let (level, message) = fromOTelLog l
+    logOtherNS "hs-opentelemetry-sdk" level message
+
+disableTracing :: TracerProviderOptions -> TracerProviderOptions
+disableTracing = const emptyTracerProviderOptions
+
+-- |
+--
+-- TODO: Use more fields, i.e. metadata
+--
+-- <https://hackage.haskell.org/package/hs-opentelemetry-api-0.0.3.6/docs/OpenTelemetry-Logging-Core.html#t:Log>
+--
+fromOTelLog :: Trace.Log Text -> (LogLevel, Message)
+fromOTelLog = fromOTelSeverity . Trace.severityNumber &&& (:# []) . Trace.body
+
+fromOTelSeverity :: Maybe Int64 -> LogLevel
+fromOTelSeverity = \case
+  Just n | n > 17 -> LevelError
+  Just n | n > 13 -> LevelWarn
+  Just n | n > 9 -> LevelInfo
+  Just n | n > 1 -> LevelDebug
+  _ -> LevelOther "unknown"

--- a/library/Freckle/App/OpenTelemetry/Wai.hs
+++ b/library/Freckle/App/OpenTelemetry/Wai.hs
@@ -1,0 +1,45 @@
+module Freckle.App.OpenTelemetry.Wai
+  ( newOpenTelemetryWaiMiddleware
+  , addTraceIdResponseHeader
+  , addTraceIdThreadContext
+  , withTraceIdMiddleware
+  ) where
+
+import Freckle.App.Prelude
+
+import Blammo.Logging (withThreadContext, (.=))
+import Freckle.App.OpenTelemetry
+import Network.Wai
+import Network.Wai.Middleware.AddHeaders
+import qualified OpenTelemetry.Instrumentation.Wai as Trace
+import OpenTelemetry.Trace.Id
+  (Base(Base16), TraceId, traceIdBaseEncodedByteString, traceIdBaseEncodedText)
+
+-- | Like "OpenTelemetry.Instrumentation.Wai" with extra 'TraceId' handling
+--
+-- - Adds an @X-OTel-TraceId@ to responses
+-- - Adds a @trace_id@ in the logging Thread Context
+--
+newOpenTelemetryWaiMiddleware :: IO Middleware
+newOpenTelemetryWaiMiddleware = do
+  otel <- Trace.newOpenTelemetryWaiMiddleware
+  pure $ otel . addTraceIdResponseHeader . addTraceIdThreadContext
+
+addTraceIdResponseHeader :: Middleware
+addTraceIdResponseHeader =
+  withTraceIdMiddleware $ \traceId app request respond -> do
+    let traceIdBS = traceIdBaseEncodedByteString Base16 traceId
+    addHeaders [("X-OTel-Trace-Id", traceIdBS)] app request respond
+
+addTraceIdThreadContext :: Middleware
+addTraceIdThreadContext =
+  withTraceIdMiddleware $ \traceId app request respond -> do
+    let traceIdHex = traceIdBaseEncodedText Base16 traceId
+    withThreadContext ["trace_id" .= traceIdHex] $ app request respond
+
+withTraceIdMiddleware :: (TraceId -> Middleware) -> Middleware
+withTraceIdMiddleware f app request respond = do
+  mTraceId <- getCurrentTraceId
+  case mTraceId of
+    Nothing -> app request respond
+    Just traceId -> f traceId app request respond

--- a/package.yaml
+++ b/package.yaml
@@ -93,6 +93,7 @@ library:
     - hashable
     - hs-opentelemetry-awsxray
     - hs-opentelemetry-instrumentation-persistent
+    - hs-opentelemetry-api
     - hs-opentelemetry-sdk
     - hspec >= 2.8.1
     - hspec-core >= 2.8.1

--- a/package.yaml
+++ b/package.yaml
@@ -91,9 +91,10 @@ library:
     - extra
     - filepath
     - hashable
+    - hs-opentelemetry-api
     - hs-opentelemetry-awsxray
     - hs-opentelemetry-instrumentation-persistent
-    - hs-opentelemetry-api
+    - hs-opentelemetry-instrumentation-wai
     - hs-opentelemetry-sdk
     - hspec >= 2.8.1
     - hspec-core >= 2.8.1

--- a/package.yaml
+++ b/package.yaml
@@ -16,12 +16,13 @@ extra-source-files:
 ghc-options:
   - -fignore-optim-changes
   - -Weverything
+  - -Wno-all-missed-specialisations
   - -Wno-missing-exported-signatures # re-enables missing-signatures
   - -Wno-missing-import-lists
   - -Wno-missing-local-signatures
   - -Wno-monomorphism-restriction
-  - -Wno-unsafe
   - -Wno-safe
+  - -Wno-unsafe
 
 when:
   - condition: "impl(ghc >= 9.2)"

--- a/stack-lts-18.28.yaml
+++ b/stack-lts-18.28.yaml
@@ -23,6 +23,7 @@ extra-deps:
   - hs-opentelemetry-awsxray-0.1.0.1
   - hs-opentelemetry-exporter-otlp-0.0.1.4
   - hs-opentelemetry-instrumentation-persistent-0.0.1.0
+  - hs-opentelemetry-instrumentation-wai-0.0.1.3
   - hs-opentelemetry-otlp-0.0.1.0
   - hs-opentelemetry-propagator-w3c-0.0.1.2
   - hs-opentelemetry-sdk-0.0.3.4

--- a/stack-lts-19.33.yaml
+++ b/stack-lts-19.33.yaml
@@ -18,6 +18,7 @@ extra-deps:
   - hs-opentelemetry-awsxray-0.1.0.1
   - hs-opentelemetry-exporter-otlp-0.0.1.4
   - hs-opentelemetry-instrumentation-persistent-0.0.1.0
+  - hs-opentelemetry-instrumentation-wai-0.0.1.3
   - hs-opentelemetry-otlp-0.0.1.0
   - hs-opentelemetry-propagator-w3c-0.0.1.2
   - hs-opentelemetry-sdk-0.0.3.4

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -7,6 +7,7 @@ extra-deps:
   - hs-opentelemetry-awsxray-0.1.0.1
   - hs-opentelemetry-exporter-otlp-0.0.1.4
   - hs-opentelemetry-instrumentation-persistent-0.0.1.0
+  - hs-opentelemetry-instrumentation-wai-0.0.1.3
   - hs-opentelemetry-otlp-0.0.1.0
   - hs-opentelemetry-propagator-w3c-0.0.1.2
   - hs-opentelemetry-sdk-0.0.3.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,6 @@ extra-deps:
   - hs-opentelemetry-exporter-otlp-0.0.1.4
   - hs-opentelemetry-instrumentation-persistent-0.0.1.0
   - hs-opentelemetry-instrumentation-wai-0.0.1.3
-  - hs-opentelemetry-instrumentation-yesod-0.0.1.3
   - hs-opentelemetry-otlp-0.0.1.0
   - hs-opentelemetry-propagator-w3c-0.0.1.2
   - hs-opentelemetry-sdk-0.0.3.4

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -47,13 +47,6 @@ packages:
   original:
     hackage: hs-opentelemetry-instrumentation-wai-0.0.1.3
 - completed:
-    hackage: hs-opentelemetry-instrumentation-yesod-0.0.1.3@sha256:e6e6923e3d320aba4d84997a41c628507cb754e4370b1fcf727b8b337908769c,1913
-    pantry-tree:
-      sha256: dcb06cc670aec9056905a9ae5cb77391183cd12c886dcf1db778818ba65fd79d
-      size: 415
-  original:
-    hackage: hs-opentelemetry-instrumentation-yesod-0.0.1.3
-- completed:
     hackage: hs-opentelemetry-otlp-0.0.1.0@sha256:88bb6b68f172a336f78018b0823f47363fb7408eb19f7301489f81ad4d5c0f33,2307
     pantry-tree:
       sha256: e56292fc693805babed3c7ba7fc54e59d2e9adbc38de6bcc659009e8b10b9a1b


### PR DESCRIPTION
### [Update package options](https://github.com/freckle/freckle-app/pull/97/commits/bdc1cefe1da3011b76910a79f345b20e3368ed07)
[bdc1cef](https://github.com/freckle/freckle-app/pull/97/commits/bdc1cefe1da3011b76910a79f345b20e3368ed07)

### [Add necessary instances to AppT](https://github.com/freckle/freckle-app/pull/97/commits/b1d74b1920c24e06a70ec516490db5584110be0c)
[b1d74b1](https://github.com/freckle/freckle-app/pull/97/commits/b1d74b1920c24e06a70ec516490db5584110be0c)

Discovered when upgrading megarepo/backend.

### [Extend Freckle.App.OpenTelementry](https://github.com/freckle/freckle-app/pull/97/commits/4a259e2916b371c7edf8d7a6539e828b24d4eab1)
[4a259e2](https://github.com/freckle/freckle-app/pull/97/commits/4a259e2916b371c7edf8d7a6539e828b24d4eab1)

- Re-export some more types required to initialize
- Add `withTracerProviderXRayLogger`
- Export individual setters and `withTracerProvider`