### PR TITLE
pb/prefactor

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -61,6 +61,7 @@ library
       Freckle.App.Yesod
       Freckle.App.Yesod.Routes
       Network.HTTP.Link.Compat
+      Network.Wai.Middleware.Cors
       Network.Wai.Middleware.Stats
       Yesod.Core.Lens
   other-modules:

--- a/library/Freckle/App.hs
+++ b/library/Freckle/App.hs
@@ -142,21 +142,29 @@
 module Freckle.App
   ( runApp
   , setLineBuffering
-  , module X
+
+  -- * Concrete transformer stack
   , AppT(..)
   , runAppT
+
+  -- * Re-exports
+  , module Freckle.App.Database
+  , module Freckle.App.OpenTelemetry
+  , module Blammo.Logging
+  , module Control.Monad.Reader
   ) where
 
 import Freckle.App.Prelude
 
-import Blammo.Logging as X
+import Blammo.Logging
+import Control.Lens (view)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Control.Monad.Primitive (PrimMonad(..))
-import Control.Monad.Reader as X
+import Control.Monad.Reader
 import Control.Monad.Trans.Resource (MonadResource, ResourceT, runResourceT)
-import Freckle.App.Database as X
-import Freckle.App.OpenTelemetry as X
+import Freckle.App.Database
+import Freckle.App.OpenTelemetry
 import System.IO (BufferMode(..), hSetBuffering, stderr, stdout)
 
 runApp

--- a/library/Freckle/App.hs
+++ b/library/Freckle/App.hs
@@ -172,7 +172,6 @@ module Freckle.App
 import Freckle.App.Prelude
 
 import Blammo.Logging
-import Control.Lens (view)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Control.Monad.Primitive (PrimMonad(..))

--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Database access for your @App@
 module Freckle.App.Database

--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE StrictData #-}
-{-# LANGUAGE TypeOperators #-}
 
 -- | Database access for your @App@
 module Freckle.App.Database

--- a/library/Freckle/App/Wai.hs
+++ b/library/Freckle/App/Wai.hs
@@ -1,77 +1,31 @@
 -- | Integration of "Freckle.App" tooling with "Network.Wai"
 module Freckle.App.Wai
   ( noCacheMiddleware
-  , corsMiddleware
   , denyFrameEmbeddingMiddleware
+
+  -- * CORS
+  , corsMiddleware
+
+  -- * Logs
+  , requestLogger
+  , addThreadContextFromRequest
+
+  -- * Metrics
+  , addThreadContextFromStatsTags
+  , requestStats
   ) where
 
-import Freckle.App.Prelude
-
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.CaseInsensitive as CI
-import Network.HTTP.Types (ResponseHeaders)
-import Network.HTTP.Types.Status (status200)
 import Network.Wai
-import Network.Wai.Middleware.AddHeaders (addHeaders)
+import Network.Wai.Middleware.AddHeaders
+import Network.Wai.Middleware.Cors
+import Network.Wai.Middleware.Logging
+import Network.Wai.Middleware.Stats
 
+-- | Middleware that adds header to disable all caching
 noCacheMiddleware :: Middleware
-noCacheMiddleware = addHeaders [cacheControlHeader]
- where
-  cacheControlHeader =
-    ("Cache-Control", "no-cache, no-store, max-age=0, private")
-
-corsMiddleware
-  :: (ByteString -> Bool)
-  -- ^ Predicate that returns 'True' for valid @Origin@ values
-  -> [ByteString]
-  -- ^ Extra headers to add to @Expose-Headers@
-  -> Middleware
-corsMiddleware validateOrigin extraExposedHeaders =
-  handleOptions validateOrigin extraExposedHeaders
-    . addCORSHeaders validateOrigin extraExposedHeaders
+noCacheMiddleware =
+  addHeaders [("Cache-Control", "no-cache, no-store, max-age=0, private")]
 
 -- | Middleware that adds header to deny all frame embedding
 denyFrameEmbeddingMiddleware :: Middleware
 denyFrameEmbeddingMiddleware = addHeaders [("X-Frame-Options", "DENY")]
-
-handleOptions :: (ByteString -> Bool) -> [ByteString] -> Middleware
-handleOptions validateOrigin extraExposedHeaders app req sendResponse =
-  case (requestMethod req, lookup "Origin" (requestHeaders req)) of
-    ("OPTIONS", Just origin) -> sendResponse $ responseLBS
-      status200
-      (toHeaders $ corsResponseHeaders validateOrigin extraExposedHeaders origin
-      )
-      mempty
-    _ -> app req sendResponse
- where
-  toHeaders :: [(ByteString, ByteString)] -> ResponseHeaders
-  toHeaders = map (first CI.mk)
-
-addCORSHeaders :: (ByteString -> Bool) -> [ByteString] -> Middleware
-addCORSHeaders validateOrigin extraExposedHeaders app req sendResponse =
-  case lookup "Origin" (requestHeaders req) of
-    Nothing -> app req sendResponse
-    Just origin -> addHeaders
-      (corsResponseHeaders validateOrigin extraExposedHeaders origin)
-      app
-      req
-      sendResponse
-
-corsResponseHeaders
-  :: (ByteString -> Bool)
-  -> [ByteString]
-  -> ByteString
-  -> [(ByteString, ByteString)]
-corsResponseHeaders validateOrigin extraExposedHeaders origin =
-  [ ("Access-Control-Allow-Origin", validatedOrigin)
-  , ("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
-  , ("Access-Control-Allow-Credentials", "true")
-  , ("Access-Control-Allow-Headers", "Content-Type, *")
-  , ("Access-Control-Expose-Headers", BS.intercalate ", " exposedHeaders)
-  ]
- where
-  validatedOrigin = if validateOrigin origin then origin else "BADORIGIN"
-
-  exposedHeaders =
-    ["Set-Cookie", "Content-Disposition", "Link"] <> extraExposedHeaders

--- a/library/Network/Wai/Middleware/Cors.hs
+++ b/library/Network/Wai/Middleware/Cors.hs
@@ -1,0 +1,65 @@
+-- | TODO: Can we use <https://hackage.haskell.org/package/wai-cors> instead?
+module Network.Wai.Middleware.Cors
+  ( corsMiddleware
+  ) where
+
+import Freckle.App.Prelude
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.CaseInsensitive as CI
+import Network.HTTP.Types (ResponseHeaders)
+import Network.HTTP.Types.Status (status200)
+import Network.Wai
+import Network.Wai.Middleware.AddHeaders
+
+corsMiddleware
+  :: (ByteString -> Bool)
+  -- ^ Predicate that returns 'True' for valid @Origin@ values
+  -> [ByteString]
+  -- ^ Extra headers to add to @Expose-Headers@
+  -> Middleware
+corsMiddleware validateOrigin extraExposedHeaders =
+  handleOptions validateOrigin extraExposedHeaders
+    . addCORSHeaders validateOrigin extraExposedHeaders
+
+handleOptions :: (ByteString -> Bool) -> [ByteString] -> Middleware
+handleOptions validateOrigin extraExposedHeaders app req sendResponse =
+  case (requestMethod req, lookup "Origin" (requestHeaders req)) of
+    ("OPTIONS", Just origin) -> sendResponse $ responseLBS
+      status200
+      (toHeaders $ corsResponseHeaders validateOrigin extraExposedHeaders origin
+      )
+      mempty
+    _ -> app req sendResponse
+ where
+  toHeaders :: [(ByteString, ByteString)] -> ResponseHeaders
+  toHeaders = map (first CI.mk)
+
+addCORSHeaders :: (ByteString -> Bool) -> [ByteString] -> Middleware
+addCORSHeaders validateOrigin extraExposedHeaders app req sendResponse =
+  case lookup "Origin" (requestHeaders req) of
+    Nothing -> app req sendResponse
+    Just origin -> addHeaders
+      (corsResponseHeaders validateOrigin extraExposedHeaders origin)
+      app
+      req
+      sendResponse
+
+corsResponseHeaders
+  :: (ByteString -> Bool)
+  -> [ByteString]
+  -> ByteString
+  -> [(ByteString, ByteString)]
+corsResponseHeaders validateOrigin extraExposedHeaders origin =
+  [ ("Access-Control-Allow-Origin", validatedOrigin)
+  , ("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
+  , ("Access-Control-Allow-Credentials", "true")
+  , ("Access-Control-Allow-Headers", "Content-Type, *")
+  , ("Access-Control-Expose-Headers", BS.intercalate ", " exposedHeaders)
+  ]
+ where
+  validatedOrigin = if validateOrigin origin then origin else "BADORIGIN"
+
+  exposedHeaders =
+    ["Set-Cookie", "Content-Disposition", "Link"] <> extraExposedHeaders


### PR DESCRIPTION
### [Re-order main module exports](https://github.com/freckle/freckle-app/pull/101/commits/12751e9d2bb6af48386cefc1a7b05e8030cb9b3f)
[12751e9](https://github.com/freckle/freckle-app/pull/101/commits/12751e9d2bb6af48386cefc1a7b05e8030cb9b3f)

Makes the Haddocks a touch more logical.

### [Update Freckle.App docs](https://github.com/freckle/freckle-app/pull/101/commits/673c00298261a37ff454ee7190772611e388ff2e)
[673c002](https://github.com/freckle/freckle-app/pull/101/commits/673c00298261a37ff454ee7190772611e388ff2e)

`HasStatsClient` is now required for 'runDB'. I didn't document the
`MonadTracer` constraint yet because satisfying it is about to look very
different.

### [Unnecessary extensions](https://github.com/freckle/freckle-app/pull/101/commits/fef0ea1cbd0d9e5dae17469c1dd322e1ba23e862)
[fef0ea1](https://github.com/freckle/freckle-app/pull/101/commits/fef0ea1cbd0d9e5dae17469c1dd322e1ba23e862)

### [Refactor Middleware](https://github.com/freckle/freckle-app/pull/101/commits/3c07b65855d1f5a7d40983e44754f59e15ccee24)
[3c07b65](https://github.com/freckle/freckle-app/pull/101/commits/3c07b65855d1f5a7d40983e44754f59e15ccee24)

* Refactor Middleware modules

  We should prefer modules dedicated to a specific concern, but then can
  use `Freckle.App.Wai` as a centralized set of "blessed" middleware. We
  may even want to export a `defaultMiddleware`-style function some day.

* Add `addThreadContextFromStatsTags`

  Normally, we rely on the fact that `withStatsClient` will take any
  configured tags and put them in the thread-context to ensure that logs
  and metrics tags agree. However, when a new thread is forked for a
  request that context is lost. Using this middleware does the same
  basic thing for the request thread. It should be used outside of
  `requestLogger`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204160834162292