### PR TITLE
Extend debuggability and fix ECS Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.9.0.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.9.0.2...main)
+
+## [v1.9.0.2](https://github.com/freckle/freckle-app/compare/v1.9.0.1...v1.9.0.2)
+
+- Fix for not setting ECS Metadata tags in `StatsClient`
 
 ## [v1.9.0.1](https://github.com/freckle/freckle-app/compare/v1.9.0.0...v1.9.0.1)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.9.0.1
+version:        1.9.0.2
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Ecs.hs
+++ b/library/Freckle/App/Ecs.hs
@@ -27,6 +27,10 @@ data EcsMetadataError
   | EcsMetadataErrorInvalidJSON HttpDecodeError
   deriving stock Show
 
+-- | Parsing for the @/@ response
+--
+-- <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html#task-metadata-endpoint-v4-examples>
+--
 data EcsContainerMetadata = EcsContainerMetadata
   { ecmDockerId :: Text
   , ecmDockerName :: Text
@@ -38,6 +42,10 @@ data EcsContainerMetadata = EcsContainerMetadata
 instance FromJSON EcsContainerMetadata where
   parseJSON = genericParseJSON $ aesonDropPrefix "ecm"
 
+-- | Parsing of the @/task@ response
+--
+-- <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html#task-metadata-endpoint-v4-response>
+--
 data EcsContainerTaskMetadata = EcsContainerTaskMetadata
   { ectmCluster :: Text
   , ectmTaskARN :: Text

--- a/library/Freckle/App/Ecs.hs
+++ b/library/Freckle/App/Ecs.hs
@@ -69,7 +69,7 @@ getEcsMetadata = do
   uri <- maybe (throwError EcsMetadataErrorNotEnabled) pure mURI
 
   EcsMetadata
-    <$> makeContainerMetadataRequest (uri <> "/")
+    <$> makeContainerMetadataRequest uri
     <*> makeContainerMetadataRequest (uri <> "/task")
 
 makeContainerMetadataRequest

--- a/library/Freckle/App/Ecs.hs
+++ b/library/Freckle/App/Ecs.hs
@@ -23,8 +23,8 @@ data EcsMetadata = EcsMetadata
 data EcsMetadataError
   = EcsMetadataErrorNotEnabled
   | EcsMetadataErrorInvalidURI String
-  | EcsMetadataErrorUnexpectedStatus Status Request
-  | EcsMetadataErrorInvalidJSON HttpDecodeError
+  | EcsMetadataErrorUnexpectedStatus Request Status
+  | EcsMetadataErrorInvalidJSON Request HttpDecodeError
   deriving stock Show
 
 -- | Parsing for the @/@ response
@@ -83,9 +83,9 @@ makeContainerMetadataRequest uri = do
 
   unless (statusIsSuccessful status)
     $ throwError
-    $ EcsMetadataErrorUnexpectedStatus status req
+    $ EcsMetadataErrorUnexpectedStatus req status
 
-  mapEither EcsMetadataErrorInvalidJSON $ getResponseBody resp
+  mapEither (EcsMetadataErrorInvalidJSON req) $ getResponseBody resp
 
 mapEither :: MonadError e m => (x -> e) -> Either x a -> m a
 mapEither f = either (throwError . f) pure

--- a/library/Freckle/App/Stats.hs
+++ b/library/Freckle/App/Stats.hs
@@ -267,8 +267,8 @@ sendMetric metricType name metricValue = do
 
 getEcsMetadataTags :: MonadIO m => m [(Text, Text)]
 getEcsMetadataTags = do
-  emMetadata <- runExceptT getEcsMetadata
-  either (([] <$) . err) (pure . maybe [] toTags) emMetadata
+  eMetadata <- runExceptT getEcsMetadata
+  either (([] <$) . err) (pure . toTags) eMetadata
  where
   err e = liftIO $ hPutStrLn stderr $ "Error reading ECS Metadata: " <> show e
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.9.0.1
+version: 1.9.0.2
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
The first few commits increased visibility in the process further. The last commit actually fixes the bug:

### [Request container metadata without trailing /](https://github.com/freckle/freckle-app/pull/103/commits/ace1f1d6a1bc2154325c391d9ff035f0f79d3ddf)
[ace1f1d](https://github.com/freckle/freckle-app/pull/103/commits/ace1f1d6a1bc2154325c391d9ff035f0f79d3ddf)

At some point this started being a 404 with the trailing `/`. Removing
it gets things working again.