### PR TITLE
Derive `MonadResource` for `AppExample`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.9.0.2...main)
 
+- Derive `MonadResource` for `AppExample`.
+
 ## [v1.9.0.2](https://github.com/freckle/freckle-app/compare/v1.9.0.1...v1.9.0.2)
 
 - Fix for not setting ECS Metadata tags in `StatsClient`

--- a/library/Freckle/App/Test.hs
+++ b/library/Freckle/App/Test.hs
@@ -36,6 +36,7 @@ import Test.Hspec as X
 import Test.Hspec.Expectations.Lifted as X hiding (expectationFailure)
 
 import Blammo.Logging
+import Conduit (MonadResource)
 import Control.Monad.Base
 import Control.Monad.Catch
 import qualified Control.Monad.Fail as Fail
@@ -74,6 +75,7 @@ newtype AppExample app a = AppExample
     , MonadThrow
     , MonadLogger
     , Fail.MonadFail
+    , MonadResource
     )
 
 -- We could derive this in newer versions of unliftio-core, but defining it by


### PR DESCRIPTION
We use `AppExample` in our test suite, and we have recently added a `MonadResource` constraint to a function that we are testing. We therefore need `AppExample` to be an instance of `MonadResource`. 