### PR TITLE
Set schema in connection from `PGSCHEMA`

### DIFF
--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -130,6 +130,7 @@ data PostgresConnectionConf = PostgresConnectionConf
   , pccDatabase :: String
   , pccPoolSize :: Int
   , pccStatementTimeout :: PostgresStatementTimeout
+  , pccSchema :: String
   }
   deriving stock (Show, Eq)
 
@@ -199,6 +200,7 @@ envParseDatabaseConf source = do
   database <- Env.var Env.nonempty "PGDATABASE" mempty
   port <- Env.var Env.auto "PGPORT" mempty
   poolSize <- Env.var Env.auto "PGPOOLSIZE" $ Env.def 10
+  schema <- Env.var Env.auto "PGSCHEMA" mempty
   statementTimeout <-
     Env.var (Env.eitherReader readPostgresStatementTimeout) "PGSTATEMENTTIMEOUT"
       $ Env.def (PostgresStatementTimeoutSeconds 120)
@@ -210,6 +212,7 @@ envParseDatabaseConf source = do
     , pccDatabase = database
     , pccPoolSize = poolSize
     , pccStatementTimeout = statementTimeout
+    , pccSchema = schema
     }
 
 data AuroraIamToken = AuroraIamToken
@@ -309,4 +312,5 @@ postgresConnectionString PostgresConnectionConf {..} password =
     , "user=" <> pccUser
     , "password=" <> password
     , "dbname=" <> pccDatabase
+    , "options=-csearch_path=" <> pccSchema
     ]


### PR DESCRIPTION
`progress-api` is setup to use a `progress` schema for its tables, rather than the default `public` schema typically used. This requires the `psql` connection to be set with a the `-csearch_path` option.

This works as expected when using a tunnel to the prod `progress-api` db for `psql` locally:

```
> ENV=progress-api ./scripts/run-command-ssh-tunnel.sh psql options=-csearch_path=progress
Null display is "<NULL>".
psql (12.15 (Ubuntu 12.15-1.pgdg22.04+1), server 12.12)
SSL connection (protocol: TLSv1.2, cipher: AES128-SHA256, bits: 128, compression: off)
Type "help" for help.

progress_prod=> \dt
                   List of relations
  Schema  |           Name           | Type  |  Owner
----------+--------------------------+-------+----------
 progress | math_question_parameters | table | postgres
(1 row)
```

Without `options=-csearch_path=progress` set, no relations are found until performing `SET search_path TO progress;`.