### PR TITLE
Sleep main thread to fix segfaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.9.1.1...main)
 
+## [v1.9.2.1](https://github.com/freckle/freckle-app/compare/v1.9.2.0...v1.9.2.1)
+
+- Fixed segfault bug in `Freckle.App.Kafka.Consumer`.
+
 ## [v1.9.2.0](https://github.com/freckle/freckle-app/compare/v1.9.1.1...v1.9.2.0)
 
 - Add `Freckle.App.Kafka.Consumer` for consuming Kafka events.

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.9.2.0
+version:        1.9.2.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.9.2.0
+version: 1.9.2.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
`progress-consumer` is segfaulting when deployed, but this change seems to fix it. Sleeping the main thread is suggested in the Immortal repo README: https://github.com/UnkindPartition/immortal