### PR TITLE
Auto-commit offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.9.1.1...main)
 
+## [v1.9.3.0](https://github.com/freckle/freckle-app/compare/v1.9.2.1...v1.9.3.0)
+
+- Auto-commit offset when consuming Kafka events.
+
 ## [v1.9.2.1](https://github.com/freckle/freckle-app/compare/v1.9.2.0...v1.9.2.1)
 
 - Fixed segfault bug in `Freckle.App.Kafka.Consumer`.

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.9.2.1
+version:        1.9.3.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Kafka/Consumer.hs
+++ b/library/Freckle/App/Kafka/Consumer.hs
@@ -160,7 +160,7 @@ runConsumer pollTimeout onMessage = do
     eMessage <-
       pollMessage consumer $ Kafka.Timeout $ timeoutMs pollTimeout
     case eMessage of
-      Left (KafkaResponseError RdKafkaRespErrTimedOut) -> logDebug $ "Polling timeout"
+      Left (KafkaResponseError RdKafkaRespErrTimedOut) -> logDebug "Polling timeout"
       Left err -> logError $ "Error polling for message from Kafka" :# ["error" .= show err]
       Right ConsumerRecord {..} -> for_ crValue $ \bs ->
         case eitherDecodeStrict bs of

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.9.2.1
+version: 1.9.3.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
Manually committing offsets when processing messages might imply that something particular happens if committing an offset is skipped, such as the message being sent again by the broker. However, this is not usually the case: as soon as an offset for a later message is committed, a broker will not send an earlier skipped message in the topic partition.

Skipping messages is fine for the only application currently consuming messages using Kafka. In a future hypothetical application in which every message must be seen exactly or at least once, manually committing offsets is not sufficient due to the aforementioned behavior. There are strategies to rewind the offset in order to re-consume data, but they are currently beyond the scope of the needs for this library.