### PR TITLE
Create Freckle.App.Async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.9.1.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.9.4.0...main)
+
+## [v1.9.4.0](https://github.com/freckle/freckle-app/compare/v1.9.3.0...v1.9.4.0)
+
+- Add `Freckle.App.Async` (primarily) for correctly managing thread context when
+  spawning new threads.
 
 ## [v1.9.3.0](https://github.com/freckle/freckle-app/compare/v1.9.2.1...v1.9.3.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -30,6 +30,7 @@ library
       Configuration.Dotenv.Compat
       Freckle.App
       Freckle.App.Aeson
+      Freckle.App.Async
       Freckle.App.Bugsnag
       Freckle.App.Bugsnag.MetaData
       Freckle.App.Csv

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.9.3.0
+version:        1.9.4.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Async.hs
+++ b/library/Freckle/App/Async.hs
@@ -1,0 +1,56 @@
+module Freckle.App.Async
+  ( async
+  , immortalCreate
+  , immortalCreateLogged
+  )
+where
+
+import Freckle.App.Prelude
+
+import Blammo.Logging
+import qualified Control.Immortal as Immortal
+import Control.Monad (forever)
+import qualified Data.Aeson.Compat as KeyMap
+import UnliftIO.Async (Async)
+import qualified UnliftIO.Async as UnliftIO
+import UnliftIO.Concurrent (threadDelay)
+import UnliftIO.Exception (SomeException, displayException)
+
+-- | 'UnliftIO.Async.async' but passing the thread context along
+async :: (MonadMask m, MonadUnliftIO m) => m a -> m (Async a)
+async f = do
+  tc <- liftIO $ KeyMap.toList <$> myThreadContext
+  UnliftIO.async $ withThreadContext tc f
+
+-- | Wrapper around creating "Control.Immortal" processes
+--
+-- Features:
+--
+-- - Ensures the thread context is correctly passed to both your spawned action
+--   and your error handler
+-- - Blocks forever after spawning your thread.
+immortalCreate
+  :: (MonadMask m, MonadUnliftIO m)
+  => (Either SomeException () -> m ())
+  -- ^ How to handle unexpected finish
+  -> m ()
+  -- ^ The action to run persistently
+  -> m a
+immortalCreate onUnexpected act = do
+  tc <- liftIO $ KeyMap.toList <$> myThreadContext
+
+  let
+    act' = withThreadContext tc act
+    onUnexpected' = withThreadContext tc . onUnexpected
+
+  void $ Immortal.create $ \thread -> do
+    Immortal.onUnexpectedFinish thread onUnexpected' act'
+
+  forever $ threadDelay maxBound
+
+-- | 'immortalCreate' with logging of unexpected finishes
+immortalCreateLogged
+  :: (MonadMask m, MonadUnliftIO m, MonadLogger m) => m () -> m a
+immortalCreateLogged = immortalCreate $ either logEx pure
+ where
+  logEx ex = logError $ "Unexpected Finish" :# ["exception" .= displayException ex]

--- a/library/Freckle/App/Kafka/Consumer.hs
+++ b/library/Freckle/App/Kafka/Consumer.hs
@@ -11,15 +11,13 @@ module Freckle.App.Kafka.Consumer
 import Freckle.App.Prelude
 
 import Blammo.Logging
-import Control.Concurrent
-import qualified Control.Immortal as Immortal
 import Control.Lens (Lens', view)
-import Control.Monad (forever)
 import Data.Aeson
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Env
+import Freckle.App.Async
 import Freckle.App.Env
 import Freckle.App.Kafka.Producer (envKafkaBrokerAddresses)
 import Kafka.Consumer hiding
@@ -30,7 +28,7 @@ import Kafka.Consumer hiding
   , subscription
   )
 import qualified Kafka.Consumer as Kafka
-import UnliftIO.Exception (bracket, displayException, throwIO)
+import UnliftIO.Exception (bracket, throwIO)
 
 data KafkaConsumerConfig = KafkaConsumerConfig
   { kafkaConsumerConfigBrokerAddresses :: NonEmpty BrokerAddress
@@ -145,7 +143,8 @@ timeoutMs = \case
   TimeoutMilliseconds ms -> ms
 
 runConsumer
-  :: ( MonadUnliftIO m
+  :: ( MonadMask m
+     , MonadUnliftIO m
      , MonadReader env m
      , MonadLogger m
      , HasKafkaConsumer env
@@ -154,22 +153,14 @@ runConsumer
   => Timeout
   -> (a -> m ())
   -> m ()
-runConsumer pollTimeout onMessage = do
-  void $ Immortal.create $ \thread -> Immortal.onUnexpectedFinish thread handleException $ do
-    consumer <- view kafkaConsumerL
-    eMessage <-
-      pollMessage consumer $ Kafka.Timeout $ timeoutMs pollTimeout
-    case eMessage of
-      Left (KafkaResponseError RdKafkaRespErrTimedOut) -> logDebug "Polling timeout"
-      Left err -> logError $ "Error polling for message from Kafka" :# ["error" .= show err]
-      Right ConsumerRecord {..} -> for_ crValue $ \bs ->
-        case eitherDecodeStrict bs of
-          Left err -> logError $ "Could not decode message value" :# ["error" .= err]
-          Right a -> onMessage a
-  forever $ liftIO $ threadDelay maxBound
- where
-  handleException = \case
-    Left ex ->
-      logError $
-        "Exception occurred in runConsumer" :# ["exception" .= displayException ex]
-    Right () -> pure ()
+runConsumer pollTimeout onMessage = immortalCreateLogged $ do
+  consumer <- view kafkaConsumerL
+  eMessage <-
+    pollMessage consumer $ Kafka.Timeout $ timeoutMs pollTimeout
+  case eMessage of
+    Left (KafkaResponseError RdKafkaRespErrTimedOut) -> logDebug "Polling timeout"
+    Left err -> logError $ "Error polling for message from Kafka" :# ["error" .= show err]
+    Right ConsumerRecord {..} -> for_ crValue $ \bs ->
+      case eitherDecodeStrict bs of
+        Left err -> logError $ "Could not decode message value" :# ["error" .= err]
+        Right a -> onMessage a

--- a/library/Freckle/App/Kafka/Producer.hs
+++ b/library/Freckle/App/Kafka/Producer.hs
@@ -22,9 +22,9 @@ import qualified Data.List.NonEmpty as NE
 import Data.Pool (Pool)
 import qualified Data.Pool as Pool
 import qualified Data.Text as T
+import Freckle.App.Async (async)
 import qualified Freckle.App.Env as Env
 import Kafka.Producer
-import UnliftIO.Async (async)
 import UnliftIO.Exception (throwString)
 import Yesod.Core.Lens
 import Yesod.Core.Types (HandlerData)
@@ -101,12 +101,12 @@ createKafkaProducerPool addresses KafkaProducerPoolConfig {..} =
   throw err = throwString $ "Failed to open kafka producer: " <> show err
 
 produceKeyedOn
-  :: ( ToJSON value
-     , ToJSON key
+  :: ( MonadUnliftIO m
      , MonadLogger m
      , MonadReader env m
      , HasKafkaProducerPool env
-     , MonadUnliftIO m
+     , ToJSON key
+     , ToJSON value
      )
   => TopicName
   -> NonEmpty value
@@ -139,12 +139,13 @@ produceKeyedOn prTopic values keyF = do
       }
 
 produceKeyedOnAsync
-  :: ( ToJSON value
-     , ToJSON key
+  :: ( MonadMask m
+     , MonadUnliftIO m
      , MonadLogger m
      , MonadReader env m
      , HasKafkaProducerPool env
-     , MonadUnliftIO m
+     , ToJSON key
+     , ToJSON value
      )
   => TopicName
   -> NonEmpty value

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.9.3.0
+version: 1.9.4.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
We make heavy use of the local thread context for maintain contextual
attributes on any log messages. It can be very easy to spawn a new
thread which lacks the parent's context. If that thread does any
logging, those details will be missing. The three places touched by this
commit all had this bug.

To fix it now, and avoid it later, `Freckle.App.Async` offers versions
of functions like `UnliftIO.Async` that do the Right Thing in this
regard. It is also a natural home for higher-level, concurrency-related
constructs, such as creating persistent processes using the `immortal`
library.
