### PR TITLE
Ensure Kafka consumers include trace_id in log context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.1.0...main)
+
+## [v1.10.0.1](https://github.com/freckle/freckle-app/compare/v1.10.0.0...v1.10.1.0)
+
+- Use `withTraceIdContext` in `Freckle.App.Kafka.Consumer.runConsumer`, ensuring
+  all logging contains the `trace_id` in context.
+- Add `getCurrentTraceIdAsDatadog` and `withTraceIdContext` to
+  `Freckle.App.OpenTelemetry`.
 
 ## [v1.10.0.0](https://github.com/freckle/freckle-app/compare/v1.9.5.1...v1.10.0.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.10.0.0
+version:        1.10.1.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.10.0.0
+version: 1.10.1.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
### [Centralize adding TraceId to the logging context](https://github.com/freckle/freckle-app/pull/121/commits/34671b2cf78ffdd0aec3a68c8d7db5f08e2bbe1f)
[34671b2](https://github.com/freckle/freckle-app/pull/121/commits/34671b2cf78ffdd0aec3a68c8d7db5f08e2bbe1f)

This commit adds some functions to OpenTelemetry for working with the
current trace-id as converted to Datadog's format and for the purposes
of setting the log context. It's then re-used in the Middleware from
which it was extracted.

This will allow us to do the same thing in other persistent-process
runners, such as Kafka consumers, just like we do in APIs through the
middleware.

### [Wrap runConsumer in withTraceIdContext](https://github.com/freckle/freckle-app/pull/121/commits/98da8d6d5173937b0807920f7431718172f433b4)
[98da8d6](https://github.com/freckle/freckle-app/pull/121/commits/98da8d6d5173937b0807920f7431718172f433b4)

This will ensure consumer logs all contain the current `trace_id`.

### [Version bump](https://github.com/freckle/freckle-app/pull/121/commits/e3a2d82dc2d651e2e67d3a9e895a76167ca55f43)