### PR TITLE
Add tracing to Memcached and Kafka operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: freckle/stack-action@v4
         with:
           stack-yaml: ${{ matrix.stack-yaml }}
+        env:
+          OTEL_TRACES_EXPORTER: none
 
   lint:
     runs-on: ubuntu-latest

--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -97,7 +97,7 @@ runDB
 runDB action = do
   pool <- asks getSqlPool
   Stats.withGauge Stats.dbConnections $
-    inSpan "runDB" defaultSpanArguments $
+    inSpan "runDB" clientSpanArguments $
       runSqlPoolWithExtensibleHooks action pool Nothing $
         setAlterBackend defaultSqlPoolHooks $
           wrapSqlBackend mempty

--- a/library/Freckle/App/Memcached.hs
+++ b/library/Freckle/App/Memcached.hs
@@ -34,8 +34,8 @@ import Data.Text.Encoding.Error (lenientDecode)
 import Freckle.App.Memcached.CacheKey
 import Freckle.App.Memcached.CacheTTL
 import Freckle.App.Memcached.Client (HasMemcachedClient (..))
-import Freckle.App.Memcached.MD5
 import qualified Freckle.App.Memcached.Client as Memcached
+import Freckle.App.Memcached.MD5
 import UnliftIO.Exception (Exception (..), handleAny)
 
 class Cachable a where

--- a/library/Freckle/App/Memcached.hs
+++ b/library/Freckle/App/Memcached.hs
@@ -36,6 +36,7 @@ import Freckle.App.Memcached.CacheTTL
 import Freckle.App.Memcached.Client (HasMemcachedClient (..))
 import qualified Freckle.App.Memcached.Client as Memcached
 import Freckle.App.Memcached.MD5
+import Freckle.App.OpenTelemetry
 import UnliftIO.Exception (Exception (..), handleAny)
 
 class Cachable a where
@@ -63,6 +64,7 @@ data Cached a
 caching
   :: ( MonadUnliftIO m
      , MonadLogger m
+     , MonadTracer m
      , MonadReader env m
      , HasMemcachedClient env
      , Cachable a
@@ -75,7 +77,12 @@ caching = cachingAs fromCachable toCachable
 
 -- | Like 'caching', but with explicit conversion functions
 cachingAs
-  :: (MonadUnliftIO m, MonadLogger m, MonadReader env m, HasMemcachedClient env)
+  :: ( MonadUnliftIO m
+     , MonadLogger m
+     , MonadTracer m
+     , MonadReader env m
+     , HasMemcachedClient env
+     )
   => (ByteString -> Either String a)
   -> (a -> ByteString)
   -> CacheKey
@@ -103,6 +110,7 @@ cachingAs from to key ttl f = do
 cachingAsJSON
   :: ( MonadUnliftIO m
      , MonadLogger m
+     , MonadTracer m
      , MonadReader env m
      , HasMemcachedClient env
      , FromJSON a
@@ -118,6 +126,7 @@ cachingAsJSON = cachingAs eitherDecodeStrict encodeStrict
 cachingAsCBOR
   :: ( MonadUnliftIO m
      , MonadLogger m
+     , MonadTracer m
      , MonadReader env m
      , HasMemcachedClient env
      , Serialise a

--- a/library/Freckle/App/Memcached/CacheKey.hs
+++ b/library/Freckle/App/Memcached/CacheKey.hs
@@ -10,6 +10,7 @@ import Freckle.App.Prelude
 import Data.Char (isControl, isSpace)
 import qualified Data.Text as T
 import Database.Memcache.Types (Key)
+import OpenTelemetry.Trace (ToAttribute (..))
 import UnliftIO.Exception (throwString)
 
 newtype CacheKey = CacheKey Text
@@ -18,6 +19,9 @@ newtype CacheKey = CacheKey Text
 
 unCacheKey :: CacheKey -> Text
 unCacheKey (CacheKey x) = x
+
+instance ToAttribute CacheKey where
+  toAttribute = toAttribute . unCacheKey
 
 -- | Build a 'CacheKey', ensuring it's valid for Memcached
 --

--- a/library/Freckle/App/Memcached/CacheTTL.hs
+++ b/library/Freckle/App/Memcached/CacheTTL.hs
@@ -9,10 +9,14 @@ import Freckle.App.Prelude
 
 import Data.Word (Word32)
 import Database.Memcache.Types (Expiration)
+import OpenTelemetry.Trace (ToAttribute (..))
 
 newtype CacheTTL = CacheTTL Int
   deriving stock (Show)
   deriving newtype (Eq, Ord, Enum, Num, Real, Integral)
+
+instance ToAttribute CacheTTL where
+  toAttribute (CacheTTL x) = toAttribute x
 
 cacheTTL :: Int -> CacheTTL
 cacheTTL = CacheTTL

--- a/library/Freckle/App/OpenTelemetry.hs
+++ b/library/Freckle/App/OpenTelemetry.hs
@@ -6,21 +6,21 @@
 --   , appTracer :: Tracer
 --   }
 --
--- instance HasTracer App where
+-- instance 'HasTracer' App where
 --   tracerL = lens appTracer $ \x y -> x { appTracer = y }
 --
 -- loadApp f = do
 --   -- ...
---   withTracerProvider $ \tracerProvider -> do
---     let appTracer = makeTracer tracerProvider "my-app" tracerOptions
+--   'withTracerProvider' $ \tracerProvider -> do
+--     let appTracer = 'makeTracer' tracerProvider "my-app" 'tracerOptions'
 --     f App {..}
 -- @
 --
--- You may need to do this even if you don't plan to manually trace things, in order to
--- satisfy the 'MonadTracer' constraint required by functions like 'runDB'. If
--- you don't need this feature, and don't plan on running an otel-collector, set
--- @OTEL_TRACES_EXPORTER=none@ in the environment, which makes all tracing a
--- no-op.
+-- You may need to do this even if you don't plan to manually trace things, in
+-- order to satisfy the 'MonadTracer' constraint required by functions like
+-- 'runDB'. If you don't need this feature, and don't plan on running an
+-- otel-collector, set @OTEL_TRACES_EXPORTER=none@ in the environment, which
+-- makes all tracing a no-op.
 --
 -- In the future, it should be possible to use @OTEL_SDK_DISABLED@ for the same
 -- purpose. See <https://github.com/iand675/hs-opentelemetry/issues/60>.

--- a/library/Freckle/App/OpenTelemetry.hs
+++ b/library/Freckle/App/OpenTelemetry.hs
@@ -32,6 +32,10 @@ module Freckle.App.OpenTelemetry
   , MonadTracer (..)
   , inSpan
   , defaultSpanArguments
+  , serverSpanArguments
+  , clientSpanArguments
+  , producerSpanArguments
+  , consumerSpanArguments
 
     -- * Querying
   , withTraceIdContext
@@ -62,6 +66,39 @@ import qualified OpenTelemetry.Trace.Core as Trace (SpanContext (..))
 import OpenTelemetry.Trace.Id (TraceId)
 import OpenTelemetry.Trace.Monad
 import UnliftIO.Exception (bracket)
+
+-- | 'defaultSpanArguments' with 'kind' set to 'Server'
+--
+-- Indicates that the span covers server-side handling of a synchronous RPC or
+-- other remote request. This span is the child of a remote @Client@ span that
+-- was expected to wait for a response.
+serverSpanArguments :: SpanArguments
+serverSpanArguments = defaultSpanArguments {kind = Server}
+
+-- | 'defaultSpanArguments' with 'kind' set to 'Kind'
+--
+-- Indicates that the span describes a synchronous request to some remote
+-- service. This span is the parent of a remote @Server@ span and waits for its
+-- response.
+clientSpanArguments :: SpanArguments
+clientSpanArguments = defaultSpanArguments {kind = Client}
+
+-- | 'defaultSpanArguments' with 'kind' set to 'Producer'
+--
+-- Indicates that the span describes the parent of an asynchronous request. This
+-- parent span is expected to end before the corresponding child @Producer@
+-- span, possibly even before the child span starts. In messaging scenarios with
+-- batching, tracing individual messages requires a new @Producer@ span per
+-- message to be created.
+producerSpanArguments :: SpanArguments
+producerSpanArguments = defaultSpanArguments {kind = Producer}
+
+-- | 'defaultSpanArguments' with 'kind' set to 'Consumer'
+--
+-- Indicates that the span describes the child of an asynchronous @Producer@
+-- request.
+consumerSpanArguments :: SpanArguments
+consumerSpanArguments = defaultSpanArguments {kind = Consumer}
 
 withTracerProvider :: MonadUnliftIO m => (TracerProvider -> m a) -> m a
 withTracerProvider =


### PR DESCRIPTION
### [Fix import order](https://github.com/freckle/freckle-app/pull/125/commits/b82b2d7f2df83f23f84c6b56599023fdfd9e3782)
[b82b2d7](https://github.com/freckle/freckle-app/pull/125/commits/b82b2d7f2df83f23f84c6b56599023fdfd9e3782)

### [Add kind-related helpers for SpanArguments](https://github.com/freckle/freckle-app/pull/125/commits/02c522f9ee2dd44c67e41d7bce04d1047155f374)
[02c522f](https://github.com/freckle/freckle-app/pull/125/commits/02c522f9ee2dd44c67e41d7bce04d1047155f374)

### [Use trace kind Client for runDB span](https://github.com/freckle/freckle-app/pull/125/commits/6ee57d5c5d1c913bf63a3c2b990c6337eb43e439)
[6ee57d5](https://github.com/freckle/freckle-app/pull/125/commits/6ee57d5c5d1c913bf63a3c2b990c6337eb43e439)

### [Add tracing to Memcached operations](https://github.com/freckle/freckle-app/pull/125/commits/b4fe4109ac1cd0d01c77aaa051f5b95407cfa9ae)
[b4fe410](https://github.com/freckle/freckle-app/pull/125/commits/b4fe4109ac1cd0d01c77aaa051f5b95407cfa9ae)

### [Add tracing to Kafka.Producer operations](https://github.com/freckle/freckle-app/pull/125/commits/59f17ae01223924560e3aeec454f08234f3226b2)
[59f17ae](https://github.com/freckle/freckle-app/pull/125/commits/59f17ae01223924560e3aeec454f08234f3226b2)

This only adds topic name to the attributes, since how to deal with
multiple values and a keying function would be somewhat arbitrary. We'll
leave out that behavior for now and possibly add something later when we
start to use this and decide what we'd want.

### [Add tracing to Kafka.Consumer operations](https://github.com/freckle/freckle-app/pull/125/commits/d8ad053059dac0b398ccffc8b3449e2f6b75f2d4)
[d8ad053](https://github.com/freckle/freckle-app/pull/125/commits/d8ad053059dac0b398ccffc8b3449e2f6b75f2d4)

This adds an outer span, and inner spans for decoding and handling the
message.

In order for spans to be correctly marked as error with exception
details, you need to "throw through" the `inSpan` function, so I had to
do that refactor too. This ultimately worked out simpler by avoiding
nested eithers and moving error handling concerns out of the main body.

### [Fixup OpenTelemetry module documentation](https://github.com/freckle/freckle-app/pull/125/commits/6b978ed5e3eaf00a4af0d570afca1374ea0718b8)
[6b978ed](https://github.com/freckle/freckle-app/pull/125/commits/6b978ed5e3eaf00a4af0d570afca1374ea0718b8)

### [Set env to disable traceing in specs](https://github.com/freckle/freckle-app/pull/125/commits/958a5d60610548aef472c801fd9723bfc32a53bf)