### PR TITLE
Run tests with JUnit from env vars, if enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.11.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.4.0...main)
 
-## [v1.11.0.0](https://github.com/freckle/freckle-app/compare/v1.10.3.0...v1.11.0.0)
+## [v1.10.4.0](https://github.com/freckle/freckle-app/compare/v1.10.3.0...v1.10.4.0)
 
 - Use JUnit formatting for test output when `JUNIT_ENABLED` environment
   variable is set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.3.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.11.0.0...main)
+
+## [v1.11.0.0](https://github.com/freckle/freckle-app/compare/v1.10.3.0...v1.11.0.0)
+
+- Use JUnit formatting for test output when `JUNIT_ENABLED` environment
+  variable is set.
+- Use environment variables to [configure JUnit][junit-env]; always prefix
+  source paths with test suite `name` and output tests to `/tmp/junit`.
+- Remove using `CIRCLECI` environment variable.
+
+[junit-env]: https://github.com/freckle/hspec-junit-formatter/blob/main/library/Test/Hspec/JUnit/Config/Env.hs
 
 ## [v1.10.3.0](https://github.com/freckle/freckle-app/compare/v1.10.2.0...v1.10.3.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.10.3.0
+version:        1.10.4.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Test/Hspec/Runner.hs
+++ b/library/Freckle/App/Test/Hspec/Runner.hs
@@ -16,6 +16,7 @@ import Test.Hspec.JUnit
   ( configWithJUnitAvailable
   , defaultJUnitConfig
   , setJUnitConfigOutputFile
+  , setJUnitConfigSourcePathPrefix
   )
 import Test.Hspec.Runner
   ( Config
@@ -74,7 +75,10 @@ runSpecJUnitAvailable spec (path, name) config =
  where
   filePath = path <> "/" <> name <> "/test_results.xml"
   junitConfig =
-    setJUnitConfigOutputFile filePath $ defaultJUnitConfig $ pack name
+    setJUnitConfigSourcePathPrefix name $
+      setJUnitConfigOutputFile filePath $
+        defaultJUnitConfig $
+          pack name
 
 makeParallelConfig :: Config -> IO Config
 makeParallelConfig config = do

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.11.0.0
+version: 1.10.4.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.10.3.0
+version: 1.11.0.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
Uses `JUNIT_ENABLED` and other env vars to trigger and configure JUnit formatting when running tests, removing the legacy `CIRCLECI` env var. JUnit configuration is overridden to set the output path to `/tmp/junit` (existing behavior) and the source path prefix of the report, which is helpful in collecting test results in a monorepo.