### PR TITLE
Add Freckle.App.Random

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.4.0...main)
 
+- Add `Freckle.App.Random`
+
 ## [v1.10.4.0](https://github.com/freckle/freckle-app/compare/v1.10.3.0...v1.10.4.0)
 
 - Use JUnit formatting for test output when `JUNIT_ENABLED` environment

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -55,6 +55,7 @@ library
       Freckle.App.Memcached.Servers
       Freckle.App.OpenTelemetry
       Freckle.App.Prelude
+      Freckle.App.Random
       Freckle.App.Scientist
       Freckle.App.Stats
       Freckle.App.Stats.Rts

--- a/library/Freckle/App/Random.hs
+++ b/library/Freckle/App/Random.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Freckle.App.Random
+  ( smallRandomSubsetOfLargeIntegerRange
+  , Range (..)
+  , inclusiveRange
+  ) where
+
+import Freckle.App.Prelude
+
+import Control.Monad.Random (MonadRandom (..), Random)
+import Control.Monad.ST (runST)
+import Control.Monad.State.Strict (execStateT, get, put)
+import Data.Functor ((<&>))
+import Data.STRef (newSTRef, readSTRef, writeSTRef)
+import Numeric.Natural (Natural)
+
+import qualified Data.Set as Set
+
+-- | A contiguous range of integers
+data Range i = Range
+  { inclusiveMinBound :: i
+  , size :: Natural
+  }
+
+inclusiveRange
+  :: Integral i
+  => i
+  -- ^ Lower bound, inclusive
+  -> i
+  -- ^ Upper bound, inclusive
+  -> Range i
+inclusiveRange a b = if a <= b then Range a (fromIntegral (b - a + 1)) else Range a 0
+
+-- | Select a fixed number of items uniformly at random
+--   from a contiguous range of integers
+--
+-- This process accommodates selecting from a large range, but only has
+-- reasonable performance when the number of items being selected is small
+-- (it is quadratic in the number of items).
+--
+-- If the requested size is greater than or equal to the range, the entire
+-- range is returned.
+--
+-- e.g. @smallRandomSubsetOfLargeIntegerRange 10 (inclusiveRange 30 70)@ may
+-- produce something like @fromList [32,34,45,54,56,58,62,63,64,65]@.
+smallRandomSubsetOfLargeIntegerRange
+  :: (MonadRandom m, Random i, Integral i)
+  => Natural
+  -- ^ How many items are wanted
+  -> Range i
+  -> m (Set i)
+smallRandomSubsetOfLargeIntegerRange n r =
+  fmap gaps $
+    flip execStateT (RangeWithGaps r Set.empty) $
+      for_ [1 .. n] $ \_ -> do
+        get >>= (lift . randomlyRemove) >>= put
+
+data RangeWithGaps i = RangeWithGaps
+  { rangeWithoutGaps :: Range i
+  , gaps :: Set i
+  -- ^ The set of items that has been removed from the larger range
+  }
+
+-- | Randomly remove an item from a 'RangeWithGaps'.
+--
+-- This selects uniformly at random an item from a 'RangeWithGaps' and
+-- removes it (adds it to the 'gaps' set).
+--
+-- If every item in the range has already been removed, this does nothing.
+randomlyRemove
+  :: (MonadRandom m, Random i, Integral i) => RangeWithGaps i -> m (RangeWithGaps i)
+randomlyRemove rg =
+  randomFromRangeWithGaps rg <&> \case
+    Nothing -> rg
+    Just i -> rg {gaps = Set.insert i (gaps rg)}
+
+-- | Randomly select an item from a 'RangeWithGaps'
+--
+-- This selects uniformly at random an item from the range that is not
+-- present in the 'gaps' set.
+randomFromRangeWithGaps
+  :: (MonadRandom m, Random i, Integral i)
+  => RangeWithGaps i
+  -> m (Maybe i)
+randomFromRangeWithGaps rg =
+  let
+    RangeWithGaps {rangeWithoutGaps, gaps} = rg
+    Range {inclusiveMinBound, size} = rangeWithoutGaps
+  in
+    if fromIntegral (Set.size gaps) == size
+      then pure Nothing
+      else
+        Just
+          <$> do
+            r <-
+              (inclusiveMinBound +)
+                <$> getRandomR (0, fromIntegral size - fromIntegral (Set.size gaps) - 1)
+            pure $ runST $ do
+              xRef <- newSTRef r
+              gapQueue <- newSTRef $ Set.toAscList gaps
+              let go = do
+                    x <- readSTRef xRef
+                    readSTRef gapQueue >>= \case
+                      g : gs | g <= x -> do
+                        writeSTRef xRef (x + 1)
+                        writeSTRef gapQueue gs
+                        go
+                      _ -> pure x
+              go


### PR DESCRIPTION
For the sake of [Let Graphula tests select more than one random entity](https://app.asana.com/0/1205102828747541/1205920572323612). With this utility available, I think it should be easy enough enough to extend `Freckle.Test.Graphula.selectRandom` to randomly generating a set of row numbers and then select where `row_number()` is in the set.