### PR TITLE
Remove unsafe decodeUtf8 in cache tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.5.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.5.1...main)
+
+## [v1.10.5.1](https://github.com/freckle/freckle-app/compare/v1.10.5.0...v1.10.5.1)
+
+- Fix decoding bug when caching non-UTF-8 values
 
 ## [v1.10.5.0](https://github.com/freckle/freckle-app/compare/v1.10.4.0...v1.10.5.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.10.5.0
+version:        1.10.5.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Memcached/Client.hs
+++ b/library/Freckle/App/Memcached/Client.hs
@@ -90,7 +90,7 @@ set k v expiration = traced $ with $ \case
         { Trace.attributes =
             HashMap.fromList
               [ ("key", Trace.toAttribute k)
-              , ("value", Trace.toAttribute $ decodeUtf8 v)
+              , ("value", byteStringToAttribute v)
               , ("expiration", Trace.toAttribute expiration)
               ]
         }

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.10.5.0
+version: 1.10.5.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
We attempt to add a `value` attribute to traces in caching, and we use
`decodeUtf8` to do so. We're encountering errors decoding some values as
UTF-8. These values in particular should decode fine, however the
library shouldn't be assuming that anyway. It should support any
`ByteString` value whatsoever. Failing here also prevents values from
being `set` at all, which can have drastic performance ramifications
that far outweigh the value of this observability-related feature.

To resolve specifically that, we use `decodeUtf8With lenientDecode`
instead. As part of that, we extract a dedicated function and also
implement a length limit, as these values could be any size. This also
gives us a handy place to document the situation.
