### PR TITLE
Use withFrozenCallStack on more exception utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.7.0...main)
 
+- Use `withFrozenCallStack` on more exception utilities to reduce noise in call stacks
+
 ## [v1.10.7.0](https://github.com/freckle/freckle-app/compare/v1.10.6.0...v1.10.7.0)
 
 - Any Bugsnag `MetaData` in an `AnnotatedException`'s annotations will now be copied

--- a/library/Freckle/App/Exception/MonadThrow.hs
+++ b/library/Freckle/App/Exception/MonadThrow.hs
@@ -37,17 +37,17 @@ import qualified Control.Monad.Catch
 
 -- Throws an exception, wrapped in 'AnnotatedException' which includes a call stack
 throwM :: forall e m a. (Exception e, MonadThrow m, HasCallStack) => e -> m a
-throwM = Annotated.throw
+throwM e = withFrozenCallStack $ Annotated.throw e
 
 throwString :: forall m a. (MonadThrow m, HasCallStack) => String -> m a
-throwString = throwM . userError
+throwString s = withFrozenCallStack $ throwM $ userError s
 
 fromJustNoteM
   :: forall m a. (MonadThrow m, HasCallStack) => String -> Maybe a -> m a
-fromJustNoteM err = maybe (throwString err) pure
+fromJustNoteM err = withFrozenCallStack $ maybe (throwString err) pure
 
 impossible :: forall m a. (MonadThrow m, HasCallStack) => m a
-impossible = throwString "Impossible"
+impossible = withFrozenCallStack $ throwString "Impossible"
 
 catch
   :: forall e m a
@@ -55,7 +55,7 @@ catch
   => m a
   -> (e -> m a)
   -> m a
-catch = withFrozenCallStack Annotated.catch
+catch action handler = withFrozenCallStack $ Annotated.catch action handler
 
 catchJust
   :: forall e b m a
@@ -91,7 +91,7 @@ try
   -> m (Either e a)
   -- ^ Returns 'Left' if the action throws an exception with a type
   --   of either @e@ or @'AnnotatedException' e@
-try = withFrozenCallStack Annotated.try
+try action = withFrozenCallStack $ Annotated.try action
 
 tryJust
   :: forall e b m a
@@ -114,5 +114,5 @@ checkpointCallStack
   -> m a
   -- ^ Action that only throws 'AnnotatedException',
   --   where the annotations include a call stack
-checkpointCallStack =
-  withFrozenCallStack Annotated.checkpointCallStack
+checkpointCallStack action =
+  withFrozenCallStack $ Annotated.checkpointCallStack action

--- a/library/Freckle/App/Exception/MonadUnliftIO.hs
+++ b/library/Freckle/App/Exception/MonadUnliftIO.hs
@@ -38,17 +38,17 @@ import qualified UnliftIO.Exception
 
 -- Throws an exception, wrapped in 'AnnotatedException' which includes a call stack
 throwM :: forall e m a. (Exception e, MonadIO m, HasCallStack) => e -> m a
-throwM = Annotated.throw
+throwM e = withFrozenCallStack $ Annotated.throw e
 
 throwString :: forall m a. (MonadIO m, HasCallStack) => String -> m a
-throwString = throwM . userError
+throwString s = withFrozenCallStack $ throwM $ userError s
 
 fromJustNoteM
   :: forall m a. (MonadIO m, HasCallStack) => String -> Maybe a -> m a
-fromJustNoteM err = maybe (throwString err) pure
+fromJustNoteM err = withFrozenCallStack $ maybe (throwString err) pure
 
 impossible :: forall m a. (MonadIO m, HasCallStack) => m a
-impossible = throwString "Impossible"
+impossible = withFrozenCallStack $ throwString "Impossible"
 
 catch
   :: forall e m a
@@ -56,7 +56,7 @@ catch
   => m a
   -> (e -> m a)
   -> m a
-catch = withFrozenCallStack Annotated.catch
+catch action handler = withFrozenCallStack $ Annotated.catch action handler
 
 catchJust
   :: forall e b m a
@@ -115,5 +115,6 @@ checkpointCallStack
   -> m a
   -- ^ Action that only throws 'AnnotatedException',
   --   where the annotations include a call stack
-checkpointCallStack =
-  withFrozenCallStack Annotated.checkpointCallStack
+checkpointCallStack action =
+  withFrozenCallStack $
+    Annotated.checkpointCallStack action


### PR DESCRIPTION
I missed a bunch of opportunities to add `withFrozenCallStack` earlier; this adds them to every definition in these modules.

Here's an example of what a snag looks like before this change.

![image](https://github.com/freckle/freckle-app/assets/399718/c7b534c8-a090-46fb-9a58-2b7b305550ee)

After this change, the `throw` and `throwM` stack frames ought to disappear.

I've also done some eta expansions here; I'm not sure if they're necessary to make `withFrozenCallStack` work because I don't have a great intuition for how it works, but it seems more clear this way.