### PR TITLE
Improve caching errors log messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work
 *.hie
+.hiedb
 dist-newstyle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.7.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.8.0...main)
 
+## [v1.10.8.0](https://github.com/freckle/freckle-app/compare/v1.10.7.0...v1.10.8.0)
+
+- Reduce logged caching errors to `WARN` and add `error.stack` to them
+- Add `Freckle.App.Exception` with `annotatedExceptionMessage` helpers
 - Use `withFrozenCallStack` on more exception utilities to reduce noise in call stacks
 
 ## [v1.10.7.0](https://github.com/freckle/freckle-app/compare/v1.10.6.0...v1.10.7.0)

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -303,6 +303,7 @@ test-suite spec
     , monad-validate
     , nonempty-containers
     , postgresql-simple
+    , text
     , vector
     , wai
     , wai-extra

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -42,6 +42,7 @@ library
       Freckle.App.Dotenv
       Freckle.App.Ecs
       Freckle.App.Env
+      Freckle.App.Exception
       Freckle.App.Exception.MonadThrow
       Freckle.App.Exception.MonadUnliftIO
       Freckle.App.Exception.Types
@@ -155,6 +156,7 @@ library
     , lens
     , memcache
     , monad-control
+    , monad-logger-aeson
     , monad-validate
     , mtl
     , network-uri

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.10.7.0
+version:        1.10.8.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Exception.hs
+++ b/library/Freckle/App/Exception.hs
@@ -1,0 +1,53 @@
+module Freckle.App.Exception
+  ( -- * Re-export of our current preferred implementation module
+
+    -- | Currently 'MonadUnliftIO'-based
+      module Freckle.App.Exception.MonadUnliftIO
+
+    -- * Helpers that are agnostic to either implementation
+  , annotatedExceptionMessage
+  , annotatedExceptionMessageFrom
+  ) where
+
+import Prelude
+
+import Control.Exception.Annotated (annotatedExceptionCallStack)
+import qualified Control.Exception.Annotated as AnnotatedException
+import Control.Monad.Logger.Aeson (Message (..), (.=))
+import Data.Aeson (object)
+import Freckle.App.Exception.MonadUnliftIO
+import GHC.Exception (prettyCallStackLines)
+
+-- | Construct a log 'Message' for any @'AnnotatedException' exception@
+--
+-- Produces a log message that works with Datadog /Standard Attributes/.
+--
+-- <https://docs.datadoghq.com/standard-attributes/?search=error.>
+--
+-- @
+-- Exception
+--    error.message: {displayException on underlying exception}
+--    error.stack: [{pretty stack trace, if available}]
+-- @
+--
+-- You are expected to call this with a @TypeApplication@, for example:
+--
+-- @
+-- 'catch' myAction $ 'logError' . 'annotatedExceptionMessage' @MyException
+-- @
+annotatedExceptionMessage :: Exception ex => AnnotatedException ex -> Message
+annotatedExceptionMessage = annotatedExceptionMessageFrom $ const "Exception"
+
+-- | Like 'annotatedExceptionMessage', but use the supplied function to
+--   construct an initial 'Message' that it will augment.
+annotatedExceptionMessageFrom
+  :: Exception ex => (ex -> Message) -> AnnotatedException ex -> Message
+annotatedExceptionMessageFrom f ann = case f ex of
+  msg :# series -> msg :# series <> ["error" .= errorObject]
+ where
+  ex = AnnotatedException.exception ann
+  errorObject =
+    object
+      [ "message" .= displayException ex
+      , "stack" .= (prettyCallStackLines <$> annotatedExceptionCallStack ann)
+      ]

--- a/library/Freckle/App/Exception.hs
+++ b/library/Freckle/App/Exception.hs
@@ -16,7 +16,7 @@ import qualified Control.Exception.Annotated as AnnotatedException
 import Control.Monad.Logger.Aeson (Message (..), (.=))
 import Data.Aeson (object)
 import Freckle.App.Exception.MonadUnliftIO
-import GHC.Exception (prettyCallStackLines)
+import GHC.Exception (prettyCallStack)
 
 -- | Construct a log 'Message' for any @'AnnotatedException' exception@
 --
@@ -27,7 +27,7 @@ import GHC.Exception (prettyCallStackLines)
 -- @
 -- Exception
 --    error.message: {displayException on underlying exception}
---    error.stack: [{pretty stack trace, if available}]
+--    error.stack: {prettyCallStack from the annotation, if available}
 -- @
 --
 -- You are expected to call this with a @TypeApplication@, for example:
@@ -49,5 +49,5 @@ annotatedExceptionMessageFrom f ann = case f ex of
   errorObject =
     object
       [ "message" .= displayException ex
-      , "stack" .= (prettyCallStackLines <$> annotatedExceptionCallStack ann)
+      , "stack" .= (prettyCallStack <$> annotatedExceptionCallStack ann)
       ]

--- a/library/Freckle/App/Memcached.hs
+++ b/library/Freckle/App/Memcached.hs
@@ -83,6 +83,7 @@ caching
      , MonadReader env m
      , HasMemcachedClient env
      , Cachable a
+     , HasCallStack
      )
   => CacheKey
   -> CacheTTL
@@ -97,6 +98,7 @@ cachingAs
      , MonadTracer m
      , MonadReader env m
      , HasMemcachedClient env
+     , HasCallStack
      )
   => (ByteString -> Either String a)
   -> (a -> ByteString)
@@ -125,6 +127,7 @@ cachingAsJSON
      , HasMemcachedClient env
      , FromJSON a
      , ToJSON a
+     , HasCallStack
      )
   => CacheKey
   -> CacheTTL
@@ -140,6 +143,7 @@ cachingAsCBOR
      , MonadReader env m
      , HasMemcachedClient env
      , Serialise a
+     , HasCallStack
      )
   => CacheKey
   -> CacheTTL

--- a/library/Freckle/App/Prelude.hs
+++ b/library/Freckle/App/Prelude.hs
@@ -135,7 +135,7 @@ import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
 import Data.Set (Set)
-import Freckle.App.Exception.MonadUnliftIO
+import Freckle.App.Exception
 import Data.Text (Text, pack, unpack)
 import Data.Time (NominalDiffTime, UTCTime, getCurrentTime)
 import Data.Vector (Vector)

--- a/package.yaml
+++ b/package.yaml
@@ -167,9 +167,10 @@ tests:
       - lens
       - lens-aeson
       - memcache
-      - postgresql-simple
       - monad-validate
       - nonempty-containers
+      - postgresql-simple
+      - text
       - vector
       - wai
       - wai-extra

--- a/package.yaml
+++ b/package.yaml
@@ -113,6 +113,7 @@ library:
     - lens
     - memcache
     - monad-control
+    - monad-logger-aeson
     - monad-validate
     - mtl
     - network-uri

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.10.7.0
+version: 1.10.8.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app

--- a/tests/Freckle/App/MemcachedSpec.hs
+++ b/tests/Freckle/App/MemcachedSpec.hs
@@ -106,5 +106,5 @@ spec = withApp loadApp $ do
       --     , "  caching, called at tests/Freckle/App/MemcachedSpec.hs:87:15 in main:Freckle.App.MemcachedSpec"
       --     ]
       Object loggedMessageMeta
-        ^? key "error" . key "stack" . _String . to (length . T.lines)
-        `shouldSatisfy` maybe False (> 1)
+        ^? key "error" . key "stack" . _String . to T.lines
+        `shouldSatisfy` maybe False (not . null)

--- a/tests/Freckle/App/MemcachedSpec.hs
+++ b/tests/Freckle/App/MemcachedSpec.hs
@@ -8,9 +8,9 @@ import Freckle.App.Test
 
 import Blammo.Logging.LogSettings
 import Blammo.Logging.Logger
-import Control.Lens (lens)
+import Control.Lens (lens, (^?))
 import Data.Aeson (Value (..))
-import Data.Aeson.Compat as KeyMap
+import Data.Aeson.Lens
 import qualified Data.List.NonEmpty as NE
 import qualified Freckle.App.Env as Env
 import Freckle.App.Memcached
@@ -92,9 +92,5 @@ spec = withApp loadApp $ do
 
       msgs <- getLoggedMessagesLenient
       let Just LoggedMessage {..} = NE.last <$> NE.nonEmpty msgs
-      loggedMessageText `shouldBe` "Error deserializing"
-      loggedMessageMeta
-        `shouldBe` KeyMap.fromList
-          [ ("action", String "deserializing")
-          , ("message", String "invalid: \"Broken\"")
-          ]
+      Object loggedMessageMeta ^? key "error" . key "message" . _String
+        `shouldBe` Just "Unable to deserialize: invalid: \"Broken\""


### PR DESCRIPTION
We're seeing a lot of `OpError ValueToLarge` errors from caching set operations. This isn't necessarily a problem, but it would be good to track down and perhaps break up whatever value is being cached. Adding `error.stack` will make that possible.

As part of this, I reduced the message log-level to `WARN` as that's what they are and how we treat them. Them appearing at `ERROR` level has confused a number of engineers.