### PR TITLE
checkpoint in liftSql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Reduce logged caching errors to `WARN` and add `error.stack` to them
 - Add `Freckle.App.Exception` with `annotatedExceptionMessage` helpers
 - Use `withFrozenCallStack` on more exception utilities to reduce noise in call stacks
+- Add `MonadUnliftIO` superclass to `MonadSqlBackend`
+- Use `checkpointCallStack` in `liftSql` to help grab more stack frames
 
 ## [v1.10.7.0](https://github.com/freckle/freckle-app/compare/v1.10.6.0...v1.10.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.8.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.9.0...main)
+
+## [v1.10.9.0](https://github.com/freckle/freckle-app/compare/v1.10.8.0...v1.10.9.0)
+
+- Add `MonadUnliftIO` superclass to `MonadSqlBackend`
+- Use `checkpointCallStack` in `liftSql` to help grab more stack frames
 
 ## [v1.10.8.0](https://github.com/freckle/freckle-app/compare/v1.10.7.0...v1.10.8.0)
 
 - Reduce logged caching errors to `WARN` and add `error.stack` to them
 - Add `Freckle.App.Exception` with `annotatedExceptionMessage` helpers
 - Use `withFrozenCallStack` on more exception utilities to reduce noise in call stacks
-- Add `MonadUnliftIO` superclass to `MonadSqlBackend`
-- Use `checkpointCallStack` in `liftSql` to help grab more stack frames
 
 ## [v1.10.7.0](https://github.com/freckle/freckle-app/compare/v1.10.6.0...v1.10.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.10.9.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.11.0.0...main)
 
-## [v1.10.9.0](https://github.com/freckle/freckle-app/compare/v1.10.8.0...v1.10.9.0)
+## [v1.11.0.0](https://github.com/freckle/freckle-app/compare/v1.10.8.0...v1.11.0.0)
 
 - Add `MonadUnliftIO` superclass to `MonadSqlBackend`
 - Use `checkpointCallStack` in `liftSql` to help grab more stack frames

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.10.9.0
+version:        1.11.0.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.10.8.0
+version:        1.10.9.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Test/Yesod.hs
+++ b/library/Freckle/App/Test/Yesod.hs
@@ -147,7 +147,7 @@ bodyContains = liftYesodExample . Yesod.Test.bodyContains
 
 -- | Clears the current cookies
 testClearCookies :: forall m site. MonadYesodExample site m => m ()
-testClearCookies = liftYesodExample $ Yesod.Test.testClearCookies
+testClearCookies = liftYesodExample Yesod.Test.testClearCookies
 
 -- | Deletes the cookie of the given name
 testDeleteCookie

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.10.8.0
+version: 1.10.9.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.10.9.0
+version: 1.11.0.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
https://app.asana.com/0/399653121150251/1206106385053669

An easy way to help get more call stack.

`MonadIO` has to promote to `MonadUnliftIO` to catch exceptions, which I think is what @pbrisbin once suggested the constraint should be in the first place.