### PR TITLE
Unwrap AnnotatedException to set error class and message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## [v1.11.0.0](https://github.com/freckle/freckle-app/compare/v1.11.0.0...v1.11.1.0)
 
-- Add `Freckle.App.Bugsnag.ErrorClass`
-- "AnnotatedException" no longer appears in the error class for Bugsnag exceptions;
+- Add modules `Freckle.App.Bugsnag.ErrorClass` and `Freckle.App.Bugsnag.Message`
+
+- "AnnotatedException" no longer appears in the error class for a Bugsnag exception;
   if the exception is `AnnotatedException e`, the annotated exception is unwrapped
-  to display only the name of the original exception without the annotation wrapper.
+  to display only the name of the original `e` without the annotation wrapper.
+
+- The annotations of an `AnnotatedException` are no longer included in the message
+  of a Bugsnag exception; if the exception is `AnnotatedException e`, the annotated
+  exception is unwrapped to display only the output from applying `displayException`
+  on the underlying exception `e`.
 
 ## [v1.11.0.0](https://github.com/freckle/freckle-app/compare/v1.10.8.0...v1.11.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.11.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.11.1.0...main)
+
+## [v1.11.0.0](https://github.com/freckle/freckle-app/compare/v1.11.0.0...v1.11.1.0)
+
+- Add `Freckle.App.Bugsnag.ErrorClass`
+- "AnnotatedException" no longer appears in the error class for Bugsnag exceptions;
+  if the exception is `AnnotatedException e`, the annotated exception is unwrapped
+  to display only the name of the original exception without the annotation wrapper.
 
 ## [v1.11.0.0](https://github.com/freckle/freckle-app/compare/v1.10.8.0...v1.11.0.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.11.0.0
+version:        1.11.1.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils
@@ -33,6 +33,7 @@ library
       Freckle.App.Async
       Freckle.App.Bugsnag
       Freckle.App.Bugsnag.CallStack
+      Freckle.App.Bugsnag.ErrorClass
       Freckle.App.Bugsnag.HttpException
       Freckle.App.Bugsnag.MetaData
       Freckle.App.Bugsnag.SqlError

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -35,6 +35,7 @@ library
       Freckle.App.Bugsnag.CallStack
       Freckle.App.Bugsnag.ErrorClass
       Freckle.App.Bugsnag.HttpException
+      Freckle.App.Bugsnag.Message
       Freckle.App.Bugsnag.MetaData
       Freckle.App.Bugsnag.SqlError
       Freckle.App.Csv

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -30,6 +30,7 @@ import Freckle.App.Async (async)
 import Freckle.App.Bugsnag.CallStack (callStackBeforeNotify)
 import Freckle.App.Bugsnag.ErrorClass (errorClassBeforeNotify)
 import Freckle.App.Bugsnag.HttpException (httpExceptionBeforeNotify)
+import Freckle.App.Bugsnag.Message (messageBeforeNotify)
 import Freckle.App.Bugsnag.MetaData (metaDataAnnotationsBeforeNotify)
 import Freckle.App.Bugsnag.SqlError (sqlErrorBeforeNotify)
 import qualified Freckle.App.Env as Env
@@ -118,3 +119,4 @@ globalBeforeNotify =
     <> httpExceptionBeforeNotify
     <> maskErrorHelpers
     <> errorClassBeforeNotify
+    <> messageBeforeNotify

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -28,6 +28,7 @@ import Data.Bugsnag.Settings (Settings (..), defaultSettings)
 import Data.List (isInfixOf)
 import Freckle.App.Async (async)
 import Freckle.App.Bugsnag.CallStack (callStackBeforeNotify)
+import Freckle.App.Bugsnag.ErrorClass (errorClassBeforeNotify)
 import Freckle.App.Bugsnag.HttpException (httpExceptionBeforeNotify)
 import Freckle.App.Bugsnag.MetaData (metaDataAnnotationsBeforeNotify)
 import Freckle.App.Bugsnag.SqlError (sqlErrorBeforeNotify)
@@ -116,3 +117,4 @@ globalBeforeNotify =
     <> sqlErrorBeforeNotify
     <> httpExceptionBeforeNotify
     <> maskErrorHelpers
+    <> errorClassBeforeNotify

--- a/library/Freckle/App/Bugsnag/ErrorClass.hs
+++ b/library/Freckle/App/Bugsnag/ErrorClass.hs
@@ -1,0 +1,33 @@
+module Freckle.App.Bugsnag.ErrorClass
+  ( errorClassBeforeNotify
+  ) where
+
+import Freckle.App.Prelude
+
+import Control.Exception.Annotated (AnnotatedException)
+import qualified Control.Exception.Annotated as Annotated
+import qualified Data.Bugsnag as Bugsnag
+import Data.Typeable (Proxy (..), typeRep)
+import Network.Bugsnag
+  ( BeforeNotify
+  , updateEventFromOriginalException
+  , updateExceptions
+  )
+
+-- | Use the exception's type name at the error class
+--
+-- If the exception type is @'AnnotatedException' WhateverExceptionType@,
+-- the 'AnnotatedException' part will be unwrapped and the error class
+-- will be @WhateverExceptionType@.
+errorClassBeforeNotify :: BeforeNotify
+errorClassBeforeNotify = updateEventFromOriginalException asAnnotatedException
+
+asAnnotatedException :: AnnotatedException SomeException -> BeforeNotify
+asAnnotatedException = updateExceptions . setErrorClass . someErrorClass . Annotated.exception
+
+-- | Unwrap the 'SomeException' newtype to get the actual underlying type name
+someErrorClass :: SomeException -> Text
+someErrorClass (SomeException (_ :: e)) = pack $ show $ typeRep $ Proxy @e
+
+setErrorClass :: Text -> Bugsnag.Exception -> Bugsnag.Exception
+setErrorClass c ex = ex {Bugsnag.exception_errorClass = c}

--- a/library/Freckle/App/Bugsnag/Message.hs
+++ b/library/Freckle/App/Bugsnag/Message.hs
@@ -1,0 +1,33 @@
+module Freckle.App.Bugsnag.Message
+  ( messageBeforeNotify
+  ) where
+
+import Freckle.App.Prelude
+
+import Control.Exception.Annotated (AnnotatedException)
+import qualified Control.Exception.Annotated as Annotated
+import qualified Data.Bugsnag as Bugsnag
+import Network.Bugsnag
+  ( BeforeNotify
+  , updateEventFromOriginalException
+  , updateExceptions
+  )
+
+-- | Use the output of 'displayException' as the exception message
+--
+-- If the exception type is @'AnnotatedException' WhateverExceptionType@,
+-- the 'AnnotatedException' part will be unwrapped and only the underlying
+-- exception, without annotations, will be displayed.
+messageBeforeNotify :: BeforeNotify
+messageBeforeNotify = updateEventFromOriginalException asAnnotatedException
+
+asAnnotatedException :: AnnotatedException SomeException -> BeforeNotify
+asAnnotatedException =
+  updateExceptions
+    . setErrorMessage
+    . pack
+    . displayException
+    . Annotated.exception
+
+setErrorMessage :: Text -> Bugsnag.Exception -> Bugsnag.Exception
+setErrorMessage c ex = ex {Bugsnag.exception_errorClass = c}

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.11.0.0
+version: 1.11.1.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
1. `AnnotatedException` shouldn't appear in the error class
2. The annotations shouldn't appear in the exception message. If particular types of `Annotation` are desired in bugsnag, they should be added explicitly. (We presently have two types of `Annotation` that we include in bugsnag events: `CallStack` and `MetaData`.)

![image](https://github.com/freckle/freckle-app/assets/399718/6d484619-4498-41a3-9f5a-4af870689b02)
