### PR TITLE
Expose 'MemcachedClient' data constructors.

### DIFF
--- a/library/Freckle/App/Memcached/Client.hs
+++ b/library/Freckle/App/Memcached/Client.hs
@@ -1,5 +1,5 @@
 module Freckle.App.Memcached.Client
-  ( MemcachedClient
+  ( MemcachedClient (..)
   , newMemcachedClient
   , withMemcachedClient
   , memcachedClientDisabled


### PR DESCRIPTION
`fancy-api` will use `memcache` to store session data. As a result, we need to be able to require a memcache client.

By exposing the data constructors, we can extract a memcache client and continue on our merry way, or take another codebase if we do not have a client.
