### PR TITLE
Explicitly loop in runConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.12.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.13.0.1...main)
+
+## [v1.13.0.1](https://github.com/freckle/freckle-app/compare/v1.13.0.0...v1.13.0.1)
+
+- Fixed issue with `runConsumer` synchronously committing offsets after every event
 
 ## [v1.13.0.0](https://github.com/freckle/freckle-app/compare/v1.12.0.1...v1.13.0.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.13.0.0
+version:        1.13.0.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,10 @@
+cradle:
+  stack:
+    - path: "./library"
+      component: "freckle-app:lib"
+
+    - path: "./doctest"
+      component: "freckle-app:test:doctest"
+
+    - path: "./tests"
+      component: "freckle-app:test:spec"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.13.0.0
+version: 1.13.0.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
We were relying on `immortal` to handle the looping for `runConsumer` which calls the `onFinish` after every loop. This makes our strategy of calling a synchronous offset commit happen on every loop instead of just on error/shutdown of the consumer.

This changes to explicitly loop in the consumer so that `onFinish` only gets called on shutdown/crashes.