### PR TITLE
Revert to auto-commit consumer strategy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.13.0.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.14.0.0...main)
+
+## [v1.14.0.0](https://github.com/freckle/freckle-app/compare/v1.13.0.1...v1.14.0.1)
+
+- Reverted changes for explicit offset committing in `runConsumer` back to the auto-commit strategy [breaking]
 
 ## [v1.13.0.1](https://github.com/freckle/freckle-app/compare/v1.13.0.0...v1.13.0.1)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.13.0.1
+version:        1.14.0.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Kafka/Consumer.hs
+++ b/library/Freckle/App/Kafka/Consumer.hs
@@ -12,6 +12,7 @@ import Freckle.App.Prelude
 
 import Blammo.Logging
 import Control.Lens (Lens', view)
+import Control.Monad (forever)
 import Data.Aeson
 import Data.ByteString (ByteString)
 import qualified Data.List.NonEmpty as NE
@@ -173,7 +174,7 @@ runConsumer
   -> (a -> m ())
   -> m ()
 runConsumer pollTimeout onMessage =
-  withTraceIdContext $ immortalCreateLogged $ do
+  withTraceIdContext $ immortalCreateLogged $ forever $ do
     consumer <- view kafkaConsumerL
 
     flip catches handlers $ inSpan "kafka.consumer" consumerSpanArguments $ do

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.13.0.1
+version: 1.14.0.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
Our attempt to manually handle offset commits introduced a large performance regression. This reverts those changes and returns to the auto-commit strategy

This also sneaks in the change from https://github.com/freckle/freckle-app/commit/d4af9f3c1563b450f2a1554316652d3002335119 to explicitly loop in `runConsumer` instead of depending on `immortal` to bring up and down threads to do the looping.