### PR TITLE
Introduce FaktoryProducerPool 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.1.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.2.0...main)
+
+## [v1.15.0.1](https://github.com/freckle/freckle-app/compare/v1.15.2.0...v1.15.1.0)
+
+- Add `FaktoryProducerPool` and `HasFaktoryProducerPool` for pooling connections to Faktory
 
 ## [v1.15.1.0](https://github.com/freckle/freckle-app/compare/v1.15.0.1...v1.15.1.0)
 
 - Add `Freckle.App.Http.Cache`
 - Add `disableRequestDecompress`
+
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.2.0...main)
 
 ## [v1.15.0.1](https://github.com/freckle/freckle-app/compare/v1.15.0.0...v1.15.0.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@
 - Add `Freckle.App.Http.Cache`
 - Add `disableRequestDecompress`
 
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.2.0...main)
-
 ## [v1.15.0.1](https://github.com/freckle/freckle-app/compare/v1.15.0.0...v1.15.0.1)
 
 - Set `service.name` when tracing Database, Memcached, and Kafka functions.

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.15.1.0
+version:        1.15.2.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -43,6 +43,7 @@ library
       Freckle.App.Exception.MonadThrow
       Freckle.App.Exception.MonadUnliftIO
       Freckle.App.Exception.Types
+      Freckle.App.Faktory.ProducerPool
       Freckle.App.Ghci
       Freckle.App.GlobalCache
       Freckle.App.Http
@@ -145,6 +146,7 @@ library
     , errors
     , exceptions
     , extra
+    , faktory
     , filepath
     , hashable
     , hs-opentelemetry-api

--- a/library/Freckle/App/Faktory/ProducerPool.hs
+++ b/library/Freckle/App/Faktory/ProducerPool.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE ApplicativeDo #-}
+
+module Freckle.App.Faktory.ProducerPool
+  ( FaktoryProducerPool
+  , FaktoryProducerPoolConfig (..)
+  , envFaktoryProducerPoolConfig
+  , HasFaktoryProducerPool (..)
+  , createFaktoryProducerPool
+  ) where
+
+import Freckle.App.Prelude
+
+import Control.Lens (Lens')
+import Data.Pool
+  ( Pool
+  , defaultPoolConfig
+  , newPool
+  , setNumStripes
+  )
+import qualified Faktory.Producer as Faktory
+import qualified Faktory.Settings as Faktory
+import qualified Freckle.App.Env as Env
+import Yesod.Core.Lens (envL, siteL)
+import Yesod.Core.Types (HandlerData)
+
+data FaktoryProducerPoolConfig = FaktoryProducerPoolConfig
+  { faktoryProducerPoolConfigStripes :: Int
+  -- ^ The number of stripes (distinct sub-pools) to maintain.
+  -- The smallest acceptable value is 1.
+  , faktoryProducerPoolConfigIdleTimeout :: NominalDiffTime
+  -- ^ Amount of time for which an unused resource is kept open.
+  -- The smallest acceptable value is 0.5 seconds.
+  --
+  -- The elapsed time before destroying a resource may be a little
+  -- longer than requested, as the reaper thread wakes at 1-second
+  -- intervals.
+  , faktoryProducerPoolConfigSize :: Int
+  -- ^ Maximum number of resources to keep open per stripe.  The
+  -- smallest acceptable value is 1.
+  --
+  -- Requests for resources will block if this limit is reached on a
+  -- single stripe, even if other stripes have idle resources
+  -- available.
+  }
+  deriving stock (Show)
+
+-- | Same defaults as 'Database.Persist.Sql.ConnectionPoolConfig'
+defaultFaktoryProducerPoolConfig :: FaktoryProducerPoolConfig
+defaultFaktoryProducerPoolConfig = FaktoryProducerPoolConfig 1 600 10
+
+envFaktoryProducerPoolConfig
+  :: Env.Parser Env.Error FaktoryProducerPoolConfig
+envFaktoryProducerPoolConfig = do
+  poolSize <- Env.var Env.auto "FAKTORY_PRODUCER_POOL_SIZE" $ Env.def 10
+  pure $
+    defaultFaktoryProducerPoolConfig {faktoryProducerPoolConfigSize = poolSize}
+
+type FaktoryProducerPool = Pool Faktory.Producer
+
+class HasFaktoryProducerPool env where
+  faktoryProducerPoolL :: Lens' env FaktoryProducerPool
+
+instance HasFaktoryProducerPool site => HasFaktoryProducerPool (HandlerData child site) where
+  faktoryProducerPoolL = envL . siteL . faktoryProducerPoolL
+
+createFaktoryProducerPool
+  :: Faktory.Settings -> FaktoryProducerPoolConfig -> IO FaktoryProducerPool
+createFaktoryProducerPool faktorySettings poolConfig =
+  newPool
+    $ setNumStripes
+      (Just $ faktoryProducerPoolConfigStripes poolConfig)
+    $ defaultPoolConfig
+      (Faktory.newProducer faktorySettings)
+      Faktory.closeProducer
+      (realToFrac $ faktoryProducerPoolConfigIdleTimeout poolConfig)
+      (faktoryProducerPoolConfigSize poolConfig)

--- a/package.yaml
+++ b/package.yaml
@@ -96,6 +96,7 @@ library:
     - errors
     - exceptions
     - extra
+    - faktory
     - filepath
     - hashable
     - hs-opentelemetry-api

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.15.1.0
+version: 1.15.2.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
We should rely on a pool of connections to Faktory when  enqueueing jobs instead of opening new connections every time. This introduce a typeclass to abstract some of that.