### PR TITLE
Add addCurrentSpanAttributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.2.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.3.0...main)
+
+## [v1.15.3.0](https://github.com/freckle/freckle-app/compare/v1.15.2.0...v1.15.3.0)
+
+- Add `Freckle.App.OpenTelemetry.addCurrentSpanAttributes`
 
 ## [v1.15.2.0](https://github.com/freckle/freckle-app/compare/v1.15.1.0...v1.15.2.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.15.2.0
+version:        1.15.3.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.15.2.0
+version: 1.15.3.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
This allows users of freckle-app to add arbitrary attributes to the
current span without having to otherwise import, or be aware of, the
OpenTelemetry library. This is particularly useful in middleware.
