### PR TITLE
Don't be Datadog-specific in OpenTelemetry module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.3.0...main)
 
+-- | __DEPRECATED__
+--
+-- This module used to wrap
+-- 'OpenTelemetry.Instrumentation.Wai.newOpenTelemetryWaiMiddleware' with
+-- additional behaviors:
+--
+-- 1. Add an @X-Datadog-Trace-Id@ response header
+-- 2. Add a 'Word64'-encoded @trace_id@ to logging context
+--
+-- (1) should be handled (better) by using an actual @datadog@ propagator. That
+-- said, it's also not necessary to do. The default propagators add trace
+-- context as thier own headers, which are sufficient to use.
+--
+-- (2) doesn't need to be 'Word64'-encoded. It seems Datadog can now work with
+-- the more common 'Base16'-encoded (i.e. hex) values. This is what
+-- 'addThreadContextFromTracing' will add for you.
+--
+-- Finally, wrapping only that remaining behavior together with the library
+-- middleware is convoluted and just not very valuable. Therefore, if you were
+-- previously doing:
+--
+
+## [v1.15.4.0](https://github.com/freckle/freckle-app/compare/v1.15.3.0...v1.15.4.0)
+
+- Add `addThreadContextFromTracing` and deprecate existing middleware
+
+  Migrating away from the deprecated middleware would look like:
+
+  ```diff
+  - import Network.Wai.Middleware.OpenTelemetry (newOpenTelemetryWaiMiddleware)
+  + import Freckle.App.Wai (addThreadContextFromRequest)
+  + import OpenTelemetry.Instrumentation.Wai (newOpenTelemetryWaiMiddleware)
+
+    traceMiddleware <- newOpenTelemetryWaiMiddleware
+
+    run 3000
+      . traceMiddleware
+  +   . addThreadContextFromRequest
+      . ...
+      $ app
+  ```
+
+- Add `withTraceContext` and deprecate existing datadog-specific functions
+
 ## [v1.15.3.0](https://github.com/freckle/freckle-app/compare/v1.15.2.0...v1.15.3.0)
 
 - Add `Freckle.App.OpenTelemetry.addCurrentSpanAttributes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,4 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.3.0...main)
-
--- | __DEPRECATED__
---
--- This module used to wrap
--- 'OpenTelemetry.Instrumentation.Wai.newOpenTelemetryWaiMiddleware' with
--- additional behaviors:
---
--- 1. Add an @X-Datadog-Trace-Id@ response header
--- 2. Add a 'Word64'-encoded @trace_id@ to logging context
---
--- (1) should be handled (better) by using an actual @datadog@ propagator. That
--- said, it's also not necessary to do. The default propagators add trace
--- context as thier own headers, which are sufficient to use.
---
--- (2) doesn't need to be 'Word64'-encoded. It seems Datadog can now work with
--- the more common 'Base16'-encoded (i.e. hex) values. This is what
--- 'addThreadContextFromTracing' will add for you.
---
--- Finally, wrapping only that remaining behavior together with the library
--- middleware is convoluted and just not very valuable. Therefore, if you were
--- previously doing:
---
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.4.0...main)
 
 ## [v1.15.4.0](https://github.com/freckle/freckle-app/compare/v1.15.3.0...v1.15.4.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -65,6 +65,7 @@ library
       Freckle.App.Memcached.MD5
       Freckle.App.Memcached.Servers
       Freckle.App.OpenTelemetry
+      Freckle.App.OpenTelemetry.ThreadContext
       Freckle.App.Prelude
       Freckle.App.Random
       Freckle.App.Scientist

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.15.3.0
+version:        1.15.4.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/library/Freckle/App/Kafka/Consumer.hs
+++ b/library/Freckle/App/Kafka/Consumer.hs
@@ -24,6 +24,7 @@ import Freckle.App.Env
 import Freckle.App.Exception (annotatedExceptionMessageFrom)
 import Freckle.App.Kafka.Producer (envKafkaBrokerAddresses)
 import Freckle.App.OpenTelemetry
+import Freckle.App.OpenTelemetry.ThreadContext
 import Kafka.Consumer hiding
   ( Timeout
   , closeConsumer
@@ -174,7 +175,7 @@ runConsumer
   -> (a -> m ())
   -> m ()
 runConsumer pollTimeout onMessage =
-  withTraceIdContext $ immortalCreateLogged $ forever $ do
+  withTraceContext $ immortalCreateLogged $ forever $ do
     consumer <- view kafkaConsumerL
 
     flip catches handlers $ inSpan "kafka.consumer" consumerSpanArguments $ do

--- a/library/Freckle/App/OpenTelemetry.hs
+++ b/library/Freckle/App/OpenTelemetry.hs
@@ -125,6 +125,7 @@ getCurrentTraceId = fmap Trace.traceId <$> getCurrentSpanContext
 getCurrentTraceIdAsDatadog :: MonadIO m => m (Maybe Word64)
 getCurrentTraceIdAsDatadog =
   fmap convertOpenTelemetryTraceIdToDatadogTraceId <$> getCurrentTraceId
+{-# DEPRECATED getCurrentTraceIdAsDatadog "Datadog can operate with Base16 ids" #-}
 
 getCurrentSpanContext :: MonadIO m => m (Maybe SpanContext)
 getCurrentSpanContext = withCurrentSpan getSpanContext
@@ -141,6 +142,7 @@ withTraceIdContext :: (MonadIO m, MonadMask m) => m a -> m a
 withTraceIdContext f = do
   mTraceId <- getCurrentTraceIdAsDatadog
   maybe f (\traceId -> withThreadContext ["trace_id" .= traceId] f) mTraceId
+{-# DEPRECATED withTraceIdContext "Use Freckle.App.OpenTelemetry.ThreadContext" #-}
 
 -- | Convert a 'ByteString' to an 'Attribute' safely
 --

--- a/library/Freckle/App/OpenTelemetry/ThreadContext.hs
+++ b/library/Freckle/App/OpenTelemetry/ThreadContext.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Freckle.App.OpenTelemetry.ThreadContext
+  ( withTraceContext
+  ) where
+
+import Freckle.App.Prelude
+
+import Blammo.Logging (MonadMask, withThreadContext)
+import Data.Aeson ((.=))
+import qualified Data.Aeson.Key as Key
+import Data.Aeson.Types (Pair)
+import Freckle.App.OpenTelemetry (getCurrentSpanContext)
+import OpenTelemetry.Trace.Core (SpanContext (..))
+import OpenTelemetry.Trace.Id
+  ( Base (..)
+  , spanIdBaseEncodedText
+  , traceIdBaseEncodedText
+  )
+import OpenTelemetry.Trace.TraceState (Key (..), TraceState (..), Value (..))
+
+-- | Add tracing context values to the logging context
+--
+-- Values are encoded to 'Base16' (e.g. hex).
+withTraceContext :: (MonadIO m, MonadMask m) => m a -> m a
+withTraceContext f = do
+  mSpanContext <- getCurrentSpanContext
+
+  case mSpanContext of
+    Nothing -> f
+    Just sc -> withThreadContext (toThreadContext sc) f
+
+toThreadContext :: SpanContext -> [Pair]
+toThreadContext SpanContext {traceId, spanId, traceState} =
+  [ "trace_id" .= traceIdBaseEncodedText Base16 traceId
+  , "span_id" .= spanIdBaseEncodedText Base16 spanId
+  , "trace_state" .= traceStatePairs
+  ]
+ where
+  traceStatePairs :: [Pair]
+  traceStatePairs = map traceStatePair $ unTraceState traceState
+
+  traceStatePair :: (Key, Value) -> Pair
+  traceStatePair = uncurry (.=) . bimap (Key.fromText . unKey) unValue
+
+unTraceState :: TraceState -> [(Key, Value)]
+unTraceState (TraceState x) = x
+
+unKey :: Key -> Text
+unKey (Key x) = x
+
+unValue :: Value -> Text
+unValue (Value x) = x

--- a/library/Freckle/App/OpenTelemetry/ThreadContext.hs
+++ b/library/Freckle/App/OpenTelemetry/ThreadContext.hs
@@ -21,7 +21,7 @@ import OpenTelemetry.Trace.TraceState (Key (..), TraceState (..), Value (..))
 
 -- | Add tracing context values to the logging context
 --
--- Values are encoded to 'Base16' (e.g. hex).
+-- Values are encoded to 'Base16' (i.e. hex).
 withTraceContext :: (MonadIO m, MonadMask m) => m a -> m a
 withTraceContext f = do
   mSpanContext <- getCurrentSpanContext

--- a/library/Freckle/App/Wai.hs
+++ b/library/Freckle/App/Wai.hs
@@ -12,12 +12,16 @@ module Freckle.App.Wai
 
     -- * Tracing
   , newOpenTelemetryWaiMiddleware
+  , addThreadContextFromTracing
 
     -- * Metrics
   , addThreadContextFromStatsTags
   , requestStats
   ) where
 
+import Freckle.App.Prelude
+
+import Freckle.App.OpenTelemetry.ThreadContext
 import Network.Wai
 import Network.Wai.Middleware.AddHeaders
 import Network.Wai.Middleware.Cors
@@ -33,3 +37,7 @@ noCacheMiddleware =
 -- | Middleware that adds header to deny all frame embedding
 denyFrameEmbeddingMiddleware :: Middleware
 denyFrameEmbeddingMiddleware = addHeaders [("X-Frame-Options", "DENY")]
+
+-- | Middleware that adds trace context to logging context
+addThreadContextFromTracing :: Middleware
+addThreadContextFromTracing app req = withTraceContext . app req

--- a/library/Network/Wai/Middleware/OpenTelemetry.hs
+++ b/library/Network/Wai/Middleware/OpenTelemetry.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Network.Wai.Middleware.OpenTelemetry
   ( newOpenTelemetryWaiMiddleware
   , openTelemetryMiddleware
@@ -15,6 +17,10 @@ newOpenTelemetryWaiMiddleware :: IO Middleware
 newOpenTelemetryWaiMiddleware = do
   otel <- Trace.newOpenTelemetryWaiMiddleware
   pure $ otel . openTelemetryMiddleware
+{-# DEPRECATED
+  newOpenTelemetryWaiMiddleware
+  "Use OpenTelemetry.Instrumentation.Wai.newOpenTelemetryWaiMiddleware"
+  #-}
 
 -- | Add 'TraceId' information to context and responses
 --
@@ -25,6 +31,7 @@ newOpenTelemetryWaiMiddleware = do
 openTelemetryMiddleware :: Middleware
 openTelemetryMiddleware app request respond =
   withTraceIdContext $ addTraceIdHeader app request respond
+{-# DEPRECATED openTelemetryMiddleware "Use addThreadContextFromTracing" #-}
 
 addTraceIdHeader :: Middleware
 addTraceIdHeader app request respond = do

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.15.3.0
+version: 1.15.4.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
The existing OpenTelemetry modules here were careful to assume and
support Datadog as a backend. This was because we thought you had to in
order for it to function. That was either not the case, or is no longer
the case, as Datadog seems able to handle default id values and even
prefers to encode them as hex in its own UI. Converting ids to a
`Word64` value is no longer necessary, and actively confusing to see.

Because of this, we can simplify and remove some of our code here. This
change deprecates various things to nudge users a certain way when
upgrading.