### PR TITLE
Add automatic tracing to MonadHttp for AppT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.15.5.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/v1.16.0.0...main)
+
+## [v1.16.0.0](https://github.com/freckle/freckle-app/compare/v1.15.5.0...v1.16.0.0)
+
+- Add tracing to HTTP requests made within `AppT`
+
+  This is a potentially breaking change for users of `AppT app` because it now
+  requires `HasTracer app`. This instance most likely already exists, since it's
+  required to use `runDB` too.
 
 ## [v1.15.5.0](https://github.com/freckle/freckle-app/compare/v1.15.4.0...v1.15.5.0)
 

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.15.5.0
+version:        1.16.0.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -66,6 +66,7 @@ library
       Freckle.App.Memcached.Servers
       Freckle.App.OpenTelemetry
       Freckle.App.OpenTelemetry.Context
+      Freckle.App.OpenTelemetry.Http
       Freckle.App.OpenTelemetry.ThreadContext
       Freckle.App.Prelude
       Freckle.App.Random

--- a/library/Freckle/App/OpenTelemetry/Http.hs
+++ b/library/Freckle/App/OpenTelemetry/Http.hs
@@ -1,0 +1,58 @@
+module Freckle.App.OpenTelemetry.Http
+  ( httpSpanName
+  , httpSpanArguments
+  , httpAttributes
+  , httpResponseAttributes
+  ) where
+
+import Freckle.App.Prelude
+
+import qualified Data.CaseInsensitive as CI
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (lenientDecode)
+import Freckle.App.OpenTelemetry
+  ( SpanArguments (..)
+  , byteStringToAttribute
+  , clientSpanArguments
+  )
+import Network.HTTP.Client (Request, Response)
+import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Types.Status (statusCode)
+import OpenTelemetry.Attributes (Attribute, ToAttribute (..))
+
+httpSpanName :: Request -> Text
+httpSpanName req =
+  decodeUtf8With lenientDecode $ HTTP.method req <> " " <> HTTP.path req
+
+httpSpanArguments :: Request -> SpanArguments
+httpSpanArguments req = clientSpanArguments {attributes = httpAttributes req}
+
+httpAttributes :: Request -> HashMap Text Attribute
+httpAttributes req =
+  HashMap.fromList
+    [ ("service.name", byteStringToAttribute $ HTTP.host req)
+    , ("resource.name", toAttribute $ httpSpanName req)
+    , ("http.host", byteStringToAttribute $ HTTP.host req)
+    , ("http.method", byteStringToAttribute $ HTTP.method req)
+    , ("http.path", byteStringToAttribute $ HTTP.path req)
+    , ("http.query", byteStringToAttribute $ HTTP.queryString req)
+    ]
+
+httpResponseAttributes :: Response body -> HashMap Text Attribute
+httpResponseAttributes resp = statusAttr <> foldMap (uncurry headerAttr) (HTTP.responseHeaders resp)
+ where
+  statusAttr =
+    HashMap.singleton "http.status_code"
+      . toAttribute
+      . statusCode
+      $ HTTP.responseStatus resp
+
+  headerAttr k = HashMap.singleton (headerAttrKey k) . byteStringToAttribute
+
+  headerAttrKey =
+    ("http.response.headers." <>)
+      . T.toLower
+      . decodeUtf8With lenientDecode
+      . CI.original

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.15.5.0
+version: 1.16.0.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
This wraps all HTTP calls made within AppT with a span that includes a
name and attributes about the request and response. Individual functions
for generating names and attribute are also present, for use when making
similar instances.
