### PR TITLE
Language updates

### DIFF
--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -116,7 +116,7 @@ library
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe
+  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe
   build-depends:
       Blammo
     , Glob
@@ -202,8 +202,6 @@ library
   default-language: Haskell2010
   if impl(ghc >= 9.8)
     ghc-options: -Wno-missing-role-annotations
-  if impl(ghc >= 9.2)
-    ghc-options: -Wno-missing-kind-signatures
 
 test-suite doctest
   type: exitcode-stdio-1.0
@@ -238,15 +236,13 @@ test-suite doctest
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe
+  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe
   build-depends:
       base <5
     , freckle-app
   default-language: Haskell2010
   if impl(ghc >= 9.8)
     ghc-options: -Wno-missing-role-annotations
-  if impl(ghc >= 9.2)
-    ghc-options: -Wno-missing-kind-signatures
 
 test-suite spec
   type: exitcode-stdio-1.0
@@ -294,7 +290,7 @@ test-suite spec
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe -threaded -rtsopts "-with-rtsopts=-N"
+  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe -threaded -rtsopts "-with-rtsopts=-N"
   build-depends:
       Blammo
     , QuickCheck
@@ -328,5 +324,3 @@ test-suite spec
   default-language: Haskell2010
   if impl(ghc >= 9.8)
     ghc-options: -Wno-missing-role-annotations
-  if impl(ghc >= 9.2)
-    ghc-options: -Wno-missing-kind-signatures

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -187,7 +187,7 @@ library
     , yesod-test
   default-language: GHC2021
   if impl(ghc >= 9.8)
-    ghc-options: -Wno-missing-role-annotations
+    ghc-options: -Wno-missing-role-annotations -Wno-missing-poly-kind-signatures
 
 test-suite doctest
   type: exitcode-stdio-1.0
@@ -214,7 +214,7 @@ test-suite doctest
     , freckle-app
   default-language: GHC2021
   if impl(ghc >= 9.8)
-    ghc-options: -Wno-missing-role-annotations
+    ghc-options: -Wno-missing-role-annotations -Wno-missing-poly-kind-signatures
 
 test-suite spec
   type: exitcode-stdio-1.0
@@ -281,4 +281,4 @@ test-suite spec
     , zlib
   default-language: GHC2021
   if impl(ghc >= 9.8)
-    ghc-options: -Wno-missing-role-annotations
+    ghc-options: -Wno-missing-role-annotations -Wno-missing-poly-kind-signatures

--- a/freckle-app.cabal
+++ b/freckle-app.cabal
@@ -91,30 +91,16 @@ library
   hs-source-dirs:
       library
   default-extensions:
-      BangPatterns
       DataKinds
       DeriveAnyClass
-      DeriveFoldable
-      DeriveFunctor
-      DeriveGeneric
-      DeriveLift
-      DeriveTraversable
       DerivingVia
       DerivingStrategies
-      FlexibleContexts
-      FlexibleInstances
       GADTs
-      GeneralizedNewtypeDeriving
       LambdaCase
-      MultiParamTypeClasses
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings
-      RankNTypes
       RecordWildCards
-      ScopedTypeVariables
-      StandaloneDeriving
-      TypeApplications
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe
   build-depends:
@@ -199,7 +185,7 @@ library
     , yaml
     , yesod-core
     , yesod-test
-  default-language: Haskell2010
+  default-language: GHC2021
   if impl(ghc >= 9.8)
     ghc-options: -Wno-missing-role-annotations
 
@@ -211,36 +197,22 @@ test-suite doctest
   hs-source-dirs:
       doctest
   default-extensions:
-      BangPatterns
       DataKinds
       DeriveAnyClass
-      DeriveFoldable
-      DeriveFunctor
-      DeriveGeneric
-      DeriveLift
-      DeriveTraversable
       DerivingVia
       DerivingStrategies
-      FlexibleContexts
-      FlexibleInstances
       GADTs
-      GeneralizedNewtypeDeriving
       LambdaCase
-      MultiParamTypeClasses
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings
-      RankNTypes
       RecordWildCards
-      ScopedTypeVariables
-      StandaloneDeriving
-      TypeApplications
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe
   build-depends:
       base <5
     , freckle-app
-  default-language: Haskell2010
+  default-language: GHC2021
   if impl(ghc >= 9.8)
     ghc-options: -Wno-missing-role-annotations
 
@@ -265,30 +237,16 @@ test-suite spec
   hs-source-dirs:
       tests
   default-extensions:
-      BangPatterns
       DataKinds
       DeriveAnyClass
-      DeriveFoldable
-      DeriveFunctor
-      DeriveGeneric
-      DeriveLift
-      DeriveTraversable
       DerivingVia
       DerivingStrategies
-      FlexibleContexts
-      FlexibleInstances
       GADTs
-      GeneralizedNewtypeDeriving
       LambdaCase
-      MultiParamTypeClasses
       NoImplicitPrelude
       NoMonomorphismRestriction
       OverloadedStrings
-      RankNTypes
       RecordWildCards
-      ScopedTypeVariables
-      StandaloneDeriving
-      TypeApplications
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-prepositive-qualified-module -Wno-safe -Wno-unsafe -threaded -rtsopts "-with-rtsopts=-N"
   build-depends:
@@ -321,6 +279,6 @@ test-suite spec
     , wai
     , wai-extra
     , zlib
-  default-language: Haskell2010
+  default-language: GHC2021
   if impl(ghc >= 9.8)
     ghc-options: -Wno-missing-role-annotations

--- a/library/Freckle/App/Async.hs
+++ b/library/Freckle/App/Async.hs
@@ -8,11 +8,11 @@ where
 import Freckle.App.Prelude
 
 import Blammo.Logging
-import qualified Control.Immortal as Immortal
+import Control.Immortal qualified as Immortal
 import Control.Monad (forever)
-import qualified Data.Aeson.Compat as KeyMap
+import Data.Aeson.Compat qualified as KeyMap
 import UnliftIO.Async (Async)
-import qualified UnliftIO.Async as UnliftIO
+import UnliftIO.Async qualified as UnliftIO
 import UnliftIO.Concurrent (threadDelay)
 
 -- | 'UnliftIO.Async.async' but passing the thread context along

--- a/library/Freckle/App/Bugsnag.hs
+++ b/library/Freckle/App/Bugsnag.hs
@@ -19,7 +19,7 @@ module Freckle.App.Bugsnag
 
 import Freckle.App.Prelude
 
-import qualified Control.Exception as Base (Exception)
+import Control.Exception qualified as Base (Exception)
 import Control.Lens (Lens', view)
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.Reader (runReaderT)
@@ -29,9 +29,9 @@ import Data.List (isInfixOf)
 import Freckle.App.Async (async)
 import Freckle.App.Bugsnag.HttpException (httpExceptionBeforeNotify)
 import Freckle.App.Bugsnag.SqlError (sqlErrorBeforeNotify)
-import qualified Freckle.App.Env as Env
+import Freckle.App.Env qualified as Env
 import Network.Bugsnag hiding (notifyBugsnag, notifyBugsnagWith)
-import qualified Network.Bugsnag as Bugsnag
+import Network.Bugsnag qualified as Bugsnag
 import Yesod.Core.Lens (envL, siteL)
 import Yesod.Core.Types (HandlerData)
 

--- a/library/Freckle/App/Bugsnag/HttpException.hs
+++ b/library/Freckle/App/Bugsnag/HttpException.hs
@@ -8,9 +8,9 @@ module Freckle.App.Bugsnag.HttpException
 import Freckle.App.Prelude
 
 import Data.Bugsnag (Exception (..))
-import qualified Data.ByteString.Char8 as BS8
+import Data.ByteString.Char8 qualified as BS8
 import Freckle.App.Exception.Types (AnnotatedException)
-import qualified Freckle.App.Exception.Types as Annotated
+import Freckle.App.Exception.Types qualified as Annotated
 import Network.Bugsnag
   ( BeforeNotify
   , setGroupingHash

--- a/library/Freckle/App/Bugsnag/MetaData.hs
+++ b/library/Freckle/App/Bugsnag/MetaData.hs
@@ -18,7 +18,7 @@ import Freckle.App.Prelude
 import Blammo.Logging (myThreadContext)
 import Control.Lens (Lens', lens, to, view, (<>~))
 import Data.Aeson (Value (..))
-import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Bugsnag (Event (..))
 import Data.String (fromString)
 import Freckle.App.Stats (HasStatsClient (..), tagsL)

--- a/library/Freckle/App/Bugsnag/SqlError.hs
+++ b/library/Freckle/App/Bugsnag/SqlError.hs
@@ -17,7 +17,7 @@ import Database.PostgreSQL.Simple.Errors
   , constraintViolation
   )
 import Freckle.App.Exception.Types (AnnotatedException)
-import qualified Freckle.App.Exception.Types as Annotated
+import Freckle.App.Exception.Types qualified as Annotated
 import Network.Bugsnag
   ( BeforeNotify
   , setGroupingHash

--- a/library/Freckle/App/Csv.hs
+++ b/library/Freckle/App/Csv.hs
@@ -40,9 +40,9 @@ import Control.Monad.Validate
   )
 import Data.Aeson (KeyValue (..), ToJSON (..), object, pairs, (.=))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.Conduit.Combinators as Conduit
-import qualified Data.Conduit.Text as Conduit
+import Data.ByteString.Char8 qualified as BS8
+import Data.Conduit.Combinators qualified as Conduit
+import Data.Conduit.Text qualified as Conduit
 import Data.Csv
   ( DefaultOrdered
   , FromNamedRecord (..)
@@ -54,17 +54,17 @@ import Data.Csv
   , defaultOptions
   , headerOrder
   )
-import qualified Data.Csv.Incremental as CsvI
+import Data.Csv.Incremental qualified as CsvI
 import Data.Functor.Bind (Bind)
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.List.NonEmpty as NE
+import Data.HashMap.Strict qualified as HashMap
+import Data.List.NonEmpty qualified as NE
 import Data.Proxy (Proxy (Proxy))
 import Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
+import Data.Sequence qualified as Seq
 import Data.Sequence.NonEmpty (NESeq)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import qualified Data.Vector as V
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Data.Vector qualified as V
 
 -- | Treat CSV header line as 1
 --

--- a/library/Freckle/App/Database.hs
+++ b/library/Freckle/App/Database.hs
@@ -39,14 +39,14 @@ module Freckle.App.Database
 import Freckle.App.Prelude
 
 import Blammo.Logging
-import qualified Control.Immortal as Immortal
+import Control.Immortal qualified as Immortal
 import Control.Monad.Reader
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.HashMap.Strict as HashMap
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Lazy qualified as BSL
+import Data.HashMap.Strict qualified as HashMap
 import Data.Pool
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Database.Persist.Postgresql
   ( SqlBackend
   , SqlPersistT
@@ -66,13 +66,13 @@ import Database.PostgreSQL.Simple
   )
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Freckle.App.Env (Timeout (..))
-import qualified Freckle.App.Env as Env
+import Freckle.App.Env qualified as Env
 import Freckle.App.Exception.MonadUnliftIO
 import Freckle.App.OpenTelemetry
 import Freckle.App.Stats (HasStatsClient)
-import qualified Freckle.App.Stats as Stats
+import Freckle.App.Stats qualified as Stats
 import OpenTelemetry.Instrumentation.Persistent
-import qualified OpenTelemetry.Trace as Trace
+import OpenTelemetry.Trace qualified as Trace
 import System.Process.Typed (proc, readProcessStdout_)
 import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.IORef

--- a/library/Freckle/App/Dotenv.hs
+++ b/library/Freckle/App/Dotenv.hs
@@ -7,7 +7,7 @@ module Freckle.App.Dotenv
 
 import Freckle.App.Prelude
 
-import qualified Configuration.Dotenv as Dotenv
+import Configuration.Dotenv qualified as Dotenv
 import System.FilePath (takeDirectory, (</>))
 import UnliftIO.Directory (doesFileExist, getCurrentDirectory)
 

--- a/library/Freckle/App/Env.hs
+++ b/library/Freckle/App/Env.hs
@@ -39,11 +39,11 @@ import Freckle.App.Prelude
 
 import Control.Error.Util (note)
 import Data.Char (isDigit)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Time (defaultTimeLocale, parseTimeM)
 import Env hiding (flag)
-import qualified Env
-import qualified Prelude as Unsafe (read)
+import Env qualified
+import Prelude qualified as Unsafe (read)
 
 -- | Designates the value of a parameter when a flag is not provided.
 newtype Off a = Off a

--- a/library/Freckle/App/Exception.hs
+++ b/library/Freckle/App/Exception.hs
@@ -12,7 +12,7 @@ module Freckle.App.Exception
 import Prelude
 
 import Control.Exception.Annotated (annotatedExceptionCallStack)
-import qualified Control.Exception.Annotated as AnnotatedException
+import Control.Exception.Annotated qualified as AnnotatedException
 import Control.Monad.Logger.Aeson (Message (..), (.=))
 import Data.Aeson (object)
 import Freckle.App.Exception.MonadUnliftIO

--- a/library/Freckle/App/Exception/MonadThrow.hs
+++ b/library/Freckle/App/Exception/MonadThrow.hs
@@ -34,8 +34,8 @@ import Data.String (String)
 import GHC.IO.Exception (userError)
 import GHC.Stack (withFrozenCallStack)
 
-import qualified Control.Exception.Annotated as Annotated
-import qualified Control.Monad.Catch
+import Control.Exception.Annotated qualified as Annotated
+import Control.Monad.Catch qualified
 
 -- Throws an exception, wrapped in 'AnnotatedException' which includes a call stack
 throwM :: forall e m a. (Exception e, MonadThrow m, HasCallStack) => e -> m a

--- a/library/Freckle/App/Exception/MonadUnliftIO.hs
+++ b/library/Freckle/App/Exception/MonadUnliftIO.hs
@@ -35,8 +35,8 @@ import GHC.Stack (withFrozenCallStack)
 import System.IO (IO)
 import UnliftIO (MonadIO, MonadUnliftIO)
 
-import qualified Control.Exception.Annotated.UnliftIO as Annotated
-import qualified UnliftIO.Exception
+import Control.Exception.Annotated.UnliftIO qualified as Annotated
+import UnliftIO.Exception qualified
 
 -- Throws an exception, wrapped in 'AnnotatedException' which includes a call stack
 throwM :: forall e m a. (Exception e, MonadIO m, HasCallStack) => e -> m a

--- a/library/Freckle/App/Faktory/ProducerPool.hs
+++ b/library/Freckle/App/Faktory/ProducerPool.hs
@@ -17,9 +17,9 @@ import Data.Pool
   , newPool
   , setNumStripes
   )
-import qualified Faktory.Producer as Faktory
-import qualified Faktory.Settings as Faktory
-import qualified Freckle.App.Env as Env
+import Faktory.Producer qualified as Faktory
+import Faktory.Settings qualified as Faktory
+import Freckle.App.Env qualified as Env
 import Yesod.Core.Lens (envL, siteL)
 import Yesod.Core.Types (HandlerData)
 

--- a/library/Freckle/App/Ghci.hs
+++ b/library/Freckle/App/Ghci.hs
@@ -9,7 +9,7 @@ import Blammo.Logging.Simple
 import Database.Persist.Postgresql (runSqlPool)
 import Database.Persist.Sql (SqlBackend)
 import Freckle.App.Database (makePostgresPool)
-import qualified Freckle.App.Dotenv as Dotenv
+import Freckle.App.Dotenv qualified as Dotenv
 
 -- | Run a db action against .env
 runDB :: ReaderT SqlBackend IO b -> IO b

--- a/library/Freckle/App/Http.hs
+++ b/library/Freckle/App/Http.hs
@@ -82,17 +82,17 @@ import Control.Monad.Trans.Maybe (MaybeT)
 import Control.Monad.Validate (ValidateT)
 import Control.Monad.Writer (WriterT)
 import Data.Aeson (FromJSON)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy.Char8 as BSL8
-import qualified Data.List.NonEmpty as NE
+import Data.ByteString.Lazy.Char8 qualified as BSL8
+import Data.List.NonEmpty qualified as NE
 import Freckle.App.Http.Paginate
 import Freckle.App.Http.Retry
-import qualified Network.HTTP.Client as HTTP (Request (..))
+import Network.HTTP.Client qualified as HTTP (Request (..))
 import Network.HTTP.Conduit (HttpExceptionContent (..))
 import Network.HTTP.Simple hiding (httpLbs, httpNoBody)
-import qualified Network.HTTP.Simple as HTTP
+import Network.HTTP.Simple qualified as HTTP
 import Network.HTTP.Types.Header (hAccept, hAuthorization)
 import Network.HTTP.Types.Status
   ( Status

--- a/library/Freckle/App/Http/Cache.hs
+++ b/library/Freckle/App/Http/Cache.hs
@@ -16,9 +16,9 @@ import Freckle.App.Prelude
 
 import Blammo.Logging (Message (..), (.=))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.CaseInsensitive as CI
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Lazy qualified as BSL
+import Data.CaseInsensitive qualified as CI
 import Data.List.Extra (firstJust)
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
@@ -28,7 +28,7 @@ import Freckle.App.Http.Cache.Gzip
 import Freckle.App.Http.Header
 import Freckle.App.Memcached
 import Network.HTTP.Client (Request, Response)
-import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Simple
   ( addRequestHeader
   , getRequestHeader

--- a/library/Freckle/App/Http/Cache/Gzip.hs
+++ b/library/Freckle/App/Http/Cache/Gzip.hs
@@ -23,11 +23,11 @@ import Freckle.App.Prelude
 
 import Codec.Serialise (Serialise)
 import Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Freckle.App.Http (disableRequestDecompress)
 import Freckle.App.Http.Header
 import Network.HTTP.Client (Request, Response)
-import qualified Network.HTTP.Client.Internal as HTTP
+import Network.HTTP.Client.Internal qualified as HTTP
 
 newtype PotentiallyGzipped a = PotentiallyGzipped
   { unwrap :: a

--- a/library/Freckle/App/Http/Cache/Memcached.hs
+++ b/library/Freckle/App/Http/Cache/Memcached.hs
@@ -13,16 +13,16 @@ import Freckle.App.Prelude
 
 import Blammo.Logging (MonadLogger, logDebugNS, logWarnNS)
 import Codec.Serialise (Serialise (..), deserialiseOrFail, serialise)
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Data.CaseInsensitive (CI)
-import qualified Data.CaseInsensitive as CI
+import Data.CaseInsensitive qualified as CI
 import Database.Memcache.Types (Value)
 import Freckle.App.Http.Cache
 import Freckle.App.Memcached
-import qualified Freckle.App.Memcached.Client as Memcached
+import Freckle.App.Memcached.Client qualified as Memcached
 import Freckle.App.OpenTelemetry (MonadTracer)
 import Network.HTTP.Client (Request)
-import qualified Network.HTTP.Client.Internal as HTTP
+import Network.HTTP.Client.Internal qualified as HTTP
 import Network.HTTP.Types.Header (ResponseHeaders)
 import Network.HTTP.Types.Status (Status (..))
 import Network.HTTP.Types.Version (HttpVersion (..))

--- a/library/Freckle/App/Http/Cache/State.hs
+++ b/library/Freckle/App/Http/Cache/State.hs
@@ -22,7 +22,7 @@ import Control.Monad.Logger (ToLogStr (..), fromLogStr)
 import Control.Monad.State
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
-import qualified Data.Text.IO as T
+import Data.Text.IO qualified as T
 import Freckle.App.Http.Cache
 import Freckle.App.Memcached.CacheKey
 import Freckle.App.Memcached.CacheTTL

--- a/library/Freckle/App/Http/Header.hs
+++ b/library/Freckle/App/Http/Header.hs
@@ -10,7 +10,7 @@ module Freckle.App.Http.Header
 import Freckle.App.Prelude
 
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS8
+import Data.ByteString.Char8 qualified as BS8
 import Data.Char (isSpace)
 import Network.HTTP.Client (Request, Response, requestHeaders, responseHeaders)
 import Network.HTTP.Simple (getRequestHeader, getResponseHeader)

--- a/library/Freckle/App/Http/Retry.hs
+++ b/library/Freckle/App/Http/Retry.hs
@@ -7,7 +7,7 @@ module Freckle.App.Http.Retry
 import Freckle.App.Prelude
 
 import Control.Retry
-import qualified Data.ByteString.Char8 as BS8
+import Data.ByteString.Char8 qualified as BS8
 import Network.HTTP.Client (Request (..))
 import Network.HTTP.Simple
 import Network.HTTP.Types.Status (status429)

--- a/library/Freckle/App/Json/Empty.hs
+++ b/library/Freckle/App/Json/Empty.hs
@@ -5,7 +5,12 @@ module Freckle.App.Json.Empty
 
 import Freckle.App.Prelude
 
-import Autodocodec (Autodocodec (..), HasCodec (..), HasObjectCodec (..), object)
+import Autodocodec
+  ( Autodocodec (..)
+  , HasCodec (..)
+  , HasObjectCodec (..)
+  , object
+  )
 import Autodocodec.OpenAPI ()
 import Data.Aeson (FromJSON, ToJSON)
 import Data.OpenApi (ToSchema (..))

--- a/library/Freckle/App/Kafka/Consumer.hs
+++ b/library/Freckle/App/Kafka/Consumer.hs
@@ -15,10 +15,10 @@ import Control.Lens (Lens', view)
 import Control.Monad (forever)
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
-import qualified Env
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Env qualified
 import Freckle.App.Async
 import Freckle.App.Env
 import Freckle.App.Exception (annotatedExceptionMessageFrom)
@@ -32,7 +32,7 @@ import Kafka.Consumer hiding
   , runConsumer
   , subscription
   )
-import qualified Kafka.Consumer as Kafka
+import Kafka.Consumer qualified as Kafka
 import UnliftIO.Exception (bracket)
 
 data KafkaConsumerConfig = KafkaConsumerConfig

--- a/library/Freckle/App/Kafka/Producer.hs
+++ b/library/Freckle/App/Kafka/Producer.hs
@@ -92,13 +92,13 @@ createKafkaProducerPool
   -> KafkaProducerPoolConfig
   -> IO (Pool KafkaProducer)
 createKafkaProducerPool addresses KafkaProducerPoolConfig {..} =
-  Pool.newPool
-    $ Pool.setNumStripes (Just kafkaProducerPoolConfigStripes)
-    $ Pool.defaultPoolConfig
-      mkProducer
-      closeProducer
-      (realToFrac kafkaProducerPoolConfigIdleTimeout)
-      kafkaProducerPoolConfigSize
+  Pool.newPool $
+    Pool.setNumStripes (Just kafkaProducerPoolConfigStripes) $
+      Pool.defaultPoolConfig
+        mkProducer
+        closeProducer
+        (realToFrac kafkaProducerPoolConfigIdleTimeout)
+        kafkaProducerPoolConfigSize
  where
   mkProducer =
     either

--- a/library/Freckle/App/Kafka/Producer.hs
+++ b/library/Freckle/App/Kafka/Producer.hs
@@ -18,16 +18,16 @@ import Blammo.Logging
 import Control.Lens (Lens', view)
 import Data.Aeson (ToJSON, encode)
 import Data.ByteString.Lazy (toStrict)
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.List.NonEmpty as NE
+import Data.HashMap.Strict qualified as HashMap
+import Data.List.NonEmpty qualified as NE
 import Data.Pool (Pool)
-import qualified Data.Pool as Pool
-import qualified Data.Text as T
+import Data.Pool qualified as Pool
+import Data.Text qualified as T
 import Freckle.App.Async (async)
-import qualified Freckle.App.Env as Env
+import Freckle.App.Env qualified as Env
 import Freckle.App.OpenTelemetry
 import Kafka.Producer
-import qualified OpenTelemetry.Trace as Trace
+import OpenTelemetry.Trace qualified as Trace
 import UnliftIO (withRunInIO)
 import Yesod.Core.Lens
 import Yesod.Core.Types (HandlerData)

--- a/library/Freckle/App/Memcached.hs
+++ b/library/Freckle/App/Memcached.hs
@@ -28,14 +28,14 @@ import Blammo.Logging
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import Freckle.App.Exception (annotatedExceptionMessage)
 import Freckle.App.Memcached.CacheKey
 import Freckle.App.Memcached.CacheTTL
 import Freckle.App.Memcached.Client (HasMemcachedClient (..))
-import qualified Freckle.App.Memcached.Client as Memcached
+import Freckle.App.Memcached.Client qualified as Memcached
 import Freckle.App.Memcached.MD5
 import Freckle.App.OpenTelemetry
 

--- a/library/Freckle/App/Memcached/CacheKey.hs
+++ b/library/Freckle/App/Memcached/CacheKey.hs
@@ -8,7 +8,7 @@ module Freckle.App.Memcached.CacheKey
 import Freckle.App.Prelude
 
 import Data.Char (isControl, isSpace)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Database.Memcache.Types (Key)
 import OpenTelemetry.Trace (ToAttribute (..))
 

--- a/library/Freckle/App/Memcached/Client.hs
+++ b/library/Freckle/App/Memcached/Client.hs
@@ -12,14 +12,14 @@ module Freckle.App.Memcached.Client
 import Freckle.App.Prelude
 
 import Control.Lens (Lens', view, _1)
-import qualified Data.HashMap.Strict as HashMap
-import qualified Database.Memcache.Client as Memcache
+import Data.HashMap.Strict qualified as HashMap
+import Database.Memcache.Client qualified as Memcache
 import Database.Memcache.Types (Value, Version)
 import Freckle.App.Memcached.CacheKey
 import Freckle.App.Memcached.CacheTTL
 import Freckle.App.Memcached.Servers
 import Freckle.App.OpenTelemetry
-import qualified OpenTelemetry.Trace as Trace
+import OpenTelemetry.Trace qualified as Trace
 import UnliftIO.Exception (finally)
 import Yesod.Core.Lens
 import Yesod.Core.Types (HandlerData)

--- a/library/Freckle/App/Memcached/MD5.hs
+++ b/library/Freckle/App/Memcached/MD5.hs
@@ -6,8 +6,8 @@ module Freckle.App.Memcached.MD5
 
 import Freckle.App.Prelude
 
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Digest.Pure.MD5 as Digest
+import Data.ByteString.Lazy qualified as BSL
+import Data.Digest.Pure.MD5 qualified as Digest
 import Freckle.App.Memcached.CacheKey
 
 md5CacheKey :: Show a => a -> CacheKey

--- a/library/Freckle/App/Memcached/Servers.hs
+++ b/library/Freckle/App/Memcached/Servers.hs
@@ -29,8 +29,8 @@ module Freckle.App.Memcached.Servers
 import Freckle.App.Prelude
 
 import Control.Error.Util (note)
-import qualified Data.Text as T
-import qualified Database.Memcache.Client as Memcache
+import Data.Text qualified as T
+import Database.Memcache.Client qualified as Memcache
 import Network.URI (URI (..), URIAuth (..), parseAbsoluteURI)
 
 newtype MemcachedServers = MemcachedServers

--- a/library/Freckle/App/OpenTelemetry.hs
+++ b/library/Freckle/App/OpenTelemetry.hs
@@ -67,14 +67,14 @@ module Freckle.App.OpenTelemetry
 import Freckle.App.Prelude
 
 import Data.ByteString (ByteString)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import OpenTelemetry.Context (lookupSpan)
 import OpenTelemetry.Context.ThreadLocal (getContext)
 import OpenTelemetry.Trace hiding (inSpan)
 import OpenTelemetry.Trace.Core (getSpanContext)
-import qualified OpenTelemetry.Trace.Core as Trace (SpanContext (..))
+import OpenTelemetry.Trace.Core qualified as Trace (SpanContext (..))
 import OpenTelemetry.Trace.Id
   ( Base (..)
   , SpanId

--- a/library/Freckle/App/OpenTelemetry/Context.hs
+++ b/library/Freckle/App/OpenTelemetry/Context.hs
@@ -14,7 +14,7 @@ import Control.Monad.Catch (MonadMask)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.ByteString (ByteString)
 import Data.CaseInsensitive (CI)
-import qualified Data.CaseInsensitive as CI
+import Data.CaseInsensitive qualified as CI
 import Faktory.Job (Job, custom, jobOptions)
 import Faktory.Job.Custom (fromCustom, toCustom)
 import Faktory.JobOptions (JobOptions (..))

--- a/library/Freckle/App/OpenTelemetry/Http.hs
+++ b/library/Freckle/App/OpenTelemetry/Http.hs
@@ -7,9 +7,9 @@ module Freckle.App.OpenTelemetry.Http
 
 import Freckle.App.Prelude
 
-import qualified Data.CaseInsensitive as CI
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Text as T
+import Data.CaseInsensitive qualified as CI
+import Data.HashMap.Strict qualified as HashMap
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import Freckle.App.OpenTelemetry
@@ -18,7 +18,7 @@ import Freckle.App.OpenTelemetry
   , clientSpanArguments
   )
 import Network.HTTP.Client (Request, Response)
-import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Types.Status (statusCode)
 import OpenTelemetry.Attributes (Attribute, ToAttribute (..))
 

--- a/library/Freckle/App/OpenTelemetry/ThreadContext.hs
+++ b/library/Freckle/App/OpenTelemetry/ThreadContext.hs
@@ -8,7 +8,7 @@ import Freckle.App.Prelude
 
 import Blammo.Logging (MonadMask, withThreadContext)
 import Data.Aeson ((.=))
-import qualified Data.Aeson.Key as Key
+import Data.Aeson.Key qualified as Key
 import Data.Aeson.Types (Pair)
 import Freckle.App.OpenTelemetry (getCurrentSpanContext)
 import OpenTelemetry.Trace.Core (SpanContext (..))

--- a/library/Freckle/App/Prelude.hs
+++ b/library/Freckle/App/Prelude.hs
@@ -88,7 +88,7 @@ module Freckle.App.Prelude
     -- ** 'UTCTime'
   , getCurrentTime
 
-   -- * Exceptions
+    -- * Exceptions
   , throwM
   , throwString
   , fromJustNoteM
@@ -112,14 +112,14 @@ import Prelude hiding
   , head
   , init
   , last
+#if MIN_VERSION_base(4,18,0)
+  , liftA2
+#endif
   , maximum
   , minimum
   , read
   , tail
   , (!!)
-#if MIN_VERSION_base(4,18,0)
-  , liftA2
-#endif
   )
 
 -- Commonly used types (and their commonly used functions)
@@ -135,10 +135,10 @@ import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
 import Data.Set (Set)
-import Freckle.App.Exception
 import Data.Text (Text, pack, unpack)
 import Data.Time (NominalDiffTime, UTCTime, getCurrentTime)
 import Data.Vector (Vector)
+import Freckle.App.Exception
 import GHC.Generics (Generic)
 
 -- Safe alternatives to prelude functions

--- a/library/Freckle/App/Random.hs
+++ b/library/Freckle/App/Random.hs
@@ -16,7 +16,7 @@ import Data.Functor ((<&>))
 import Data.STRef (newSTRef, readSTRef, writeSTRef)
 import Numeric.Natural (Natural)
 
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 
 -- | A possibly-empty contiguous range of integers
 data Range i

--- a/library/Freckle/App/Scientist.hs
+++ b/library/Freckle/App/Scientist.hs
@@ -5,7 +5,7 @@ module Freckle.App.Scientist
 import Freckle.App.Prelude
 
 import Freckle.App.Stats (HasStatsClient)
-import qualified Freckle.App.Stats as Stats
+import Freckle.App.Stats qualified as Stats
 import Scientist
 import Scientist.Duration
 

--- a/library/Freckle/App/Stats.hs
+++ b/library/Freckle/App/Stats.hs
@@ -178,9 +178,9 @@ withGauge
 withGauge getGauge f = do
   gauge' <- lookupGauge getGauge
   bracket_ (inc gauge') (dec gauge') f
-  where
-    inc = incGauge
-    dec = decGauge
+ where
+  inc = incGauge
+  dec = decGauge
 
 lookupGauge
   :: (MonadReader app m, HasStatsClient app)

--- a/library/Freckle/App/Stats.hs
+++ b/library/Freckle/App/Stats.hs
@@ -44,10 +44,10 @@ import Data.Aeson (Value (..))
 import Data.String
 import Data.Time (diffUTCTime)
 import Freckle.App.Ecs
-import qualified Freckle.App.Env as Env
-import qualified Network.StatsD.Datadog as Datadog
+import Freckle.App.Env qualified as Env
+import Network.StatsD.Datadog qualified as Datadog
 import System.IO (hPutStrLn, stderr)
-import qualified System.Metrics.Gauge as EKG
+import System.Metrics.Gauge qualified as EKG
 import UnliftIO.Exception (bracket_)
 import Yesod.Core.Lens
 import Yesod.Core.Types (HandlerData)

--- a/library/Freckle/App/Stats/Rts.hs
+++ b/library/Freckle/App/Stats/Rts.hs
@@ -5,12 +5,12 @@ module Freckle.App.Stats.Rts
 
 import Freckle.App.Prelude
 
-import qualified Control.Immortal as Immortal
-import qualified Data.HashMap.Strict as HashMap
+import Control.Immortal qualified as Immortal
+import Data.HashMap.Strict qualified as HashMap
 import Freckle.App.Stats (HasStatsClient)
-import qualified Freckle.App.Stats as Stats
-import qualified System.Metrics as Ekg
-import qualified System.Metrics.Distribution.Internal as Ekg
+import Freckle.App.Stats qualified as Stats
+import System.Metrics qualified as Ekg
+import System.Metrics.Distribution.Internal qualified as Ekg
 import UnliftIO.Concurrent (threadDelay)
 
 -- | Initialize a thread to poll RTS stats

--- a/library/Freckle/App/Test.hs
+++ b/library/Freckle/App/Test.hs
@@ -37,8 +37,8 @@ import Blammo.Logging
 import Control.Lens (view)
 import Control.Monad.Base
 import Control.Monad.Catch (ExitCase (..), MonadCatch, MonadThrow, mask)
-import qualified Control.Monad.Catch
-import qualified Control.Monad.Fail as Fail
+import Control.Monad.Catch qualified
+import Control.Monad.Fail qualified as Fail
 import Control.Monad.Primitive
 import Control.Monad.Random (MonadRandom (..))
 import Control.Monad.Reader
@@ -50,13 +50,13 @@ import Freckle.App.Database
   , MonadSqlTx (..)
   , runDB
   )
-import qualified Freckle.App.Dotenv as Dotenv
-import qualified Freckle.App.Exception.MonadThrow as MonadThrow
+import Freckle.App.Dotenv qualified as Dotenv
+import Freckle.App.Exception.MonadThrow qualified as MonadThrow
 import Freckle.App.OpenTelemetry
-import qualified Test.Hspec as Hspec hiding (expectationFailure)
+import Test.Hspec qualified as Hspec hiding (expectationFailure)
 import Test.Hspec.Core.Spec (Arg, Example, SpecWith, evaluateExample)
-import qualified Test.Hspec.Expectations.Lifted as Hspec (expectationFailure)
-import qualified UnliftIO.Exception as UnliftIO
+import Test.Hspec.Expectations.Lifted qualified as Hspec (expectationFailure)
+import UnliftIO.Exception qualified as UnliftIO
 
 -- | An Hspec example over some @App@ value
 --

--- a/library/Freckle/App/Test/DocTest.hs
+++ b/library/Freckle/App/Test/DocTest.hs
@@ -13,10 +13,10 @@ import Freckle.App.Prelude
 
 import Control.Monad (filterM)
 import Data.Aeson
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
 import Data.Yaml (decodeFileThrow)
-import qualified Test.DocTest as DocTest
+import Test.DocTest qualified as DocTest
 import "Glob" System.FilePath.Glob (globDir1)
 
 -- | Run doctest on files in the given directory

--- a/library/Freckle/App/Test/Hspec/Runner.hs
+++ b/library/Freckle/App/Test/Hspec/Runner.hs
@@ -29,7 +29,7 @@ import Test.Hspec.Runner
   , hspecWithResult
   , readConfig
   )
-import qualified Prelude as Unsafe (read)
+import Prelude qualified as Unsafe (read)
 
 run :: String -> Spec -> IO ()
 run = runWith defaultConfig

--- a/library/Freckle/App/Test/Http.hs
+++ b/library/Freckle/App/Test/Http.hs
@@ -49,13 +49,13 @@ import Control.Lens (Lens', lens, view, (&), (.~), (<>~))
 import Control.Monad (filterM)
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson (ToJSON, encode)
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Lazy qualified as BSL
 import Data.List (stripPrefix)
 import Data.String (IsString (..))
 import Freckle.App.Http (MonadHttp (..))
 import Freckle.App.Test.Http.MatchRequest
 import Network.HTTP.Client (Request, Response)
-import qualified Network.HTTP.Client.Internal as HTTP
+import Network.HTTP.Client.Internal qualified as HTTP
 import Network.HTTP.Types.Header (ResponseHeaders, hAccept, hContentType)
 import Network.HTTP.Types.Status (Status, status200)
 import System.Directory (doesFileExist)
@@ -86,11 +86,11 @@ httpStubbed stubs req =
   maybe (error errorMessage) (toResponse req) $ headMay matched
  where
   (unmatched, matched) =
-    partitionEithers $
-      map
+    partitionEithers
+      $ map
         ( \stub ->
-            bimap (stub,) (const stub.response) $
-              matchRequest req stub.match
+            bimap (stub,) (const stub.response)
+              $ matchRequest req stub.match
         )
         stubs
 

--- a/library/Freckle/App/Test/Http/MatchRequest.hs
+++ b/library/Freckle/App/Test/Http/MatchRequest.hs
@@ -24,13 +24,13 @@ module Freckle.App.Test.Http.MatchRequest
 import Freckle.App.Prelude
 
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Lazy qualified as BSL
 import Data.List (isPrefixOf)
 import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Network.HTTP.Client (Request, RequestBody (..), parseRequest_)
-import qualified Network.HTTP.Client.Internal as HTTP
+import Network.HTTP.Client.Internal qualified as HTTP
 import Network.HTTP.Types.Header (Header, RequestHeaders)
 import Network.HTTP.Types.Method (Method)
 

--- a/library/Freckle/App/Test/Yesod.hs
+++ b/library/Freckle/App/Test/Yesod.hs
@@ -81,14 +81,14 @@ import Control.Monad.Trans.Resource (ResourceT)
 import Control.Monad.Validate (ValidateT)
 import Data.Aeson (FromJSON, eitherDecode)
 import Data.BCP47 (BCP47)
-import qualified Data.BCP47 as BCP47
+import Data.BCP47 qualified as BCP47
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
 import Data.CaseInsensitive (CI)
 import Data.Csv (FromNamedRecord, decodeByName)
-import qualified Data.Text as T
-import qualified Data.Vector as V
+import Data.Text qualified as T
+import Data.Vector qualified as V
 import Network.HTTP.Types.Header (hAccept, hAcceptLanguage, hContentType)
 import Network.Wai.Test (SResponse (..))
 import Test.Hspec.Expectations.Lifted (expectationFailure)
@@ -110,7 +110,7 @@ import Yesod.Test
   , setUrl
   , withResponse
   )
-import qualified Yesod.Test
+import Yesod.Test qualified
 
 class (MonadIO m, Yesod site) => MonadYesodExample site m | m -> site where
   liftYesodExample :: YesodExample site a -> m a

--- a/library/Freckle/App/Yesod.hs
+++ b/library/Freckle/App/Yesod.hs
@@ -16,9 +16,9 @@ import Freckle.App.Exception
   , withException
   )
 import Freckle.App.Stats (HasStatsClient)
-import qualified Freckle.App.Stats as Stats
+import Freckle.App.Stats qualified as Stats
 import Network.HTTP.Types (ResponseHeaders, status503)
-import qualified Network.Wai as W
+import Network.Wai qualified as W
 import Yesod.Core.Handler (HandlerFor, sendWaiResponse)
 import Yesod.Core.Types (HandlerContents)
 

--- a/library/Freckle/App/Yesod/Routes.hs
+++ b/library/Freckle/App/Yesod/Routes.hs
@@ -4,7 +4,7 @@ module Freckle.App.Yesod.Routes
 
 import Freckle.App.Prelude
 
-import qualified Language.Haskell.TH as TH
+import Language.Haskell.TH qualified as TH
 import Yesod.Routes.TH.Types
 
 -- | Lambdacase expression to print route names

--- a/library/Network/Wai/Middleware/Cors.hs
+++ b/library/Network/Wai/Middleware/Cors.hs
@@ -6,8 +6,8 @@ module Network.Wai.Middleware.Cors
 import Freckle.App.Prelude
 
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.CaseInsensitive as CI
+import Data.ByteString qualified as BS
+import Data.CaseInsensitive qualified as CI
 import Network.HTTP.Types (ResponseHeaders)
 import Network.HTTP.Types.Status (status200)
 import Network.Wai

--- a/library/Network/Wai/Middleware/Stats.hs
+++ b/library/Network/Wai/Middleware/Stats.hs
@@ -9,9 +9,9 @@ import Blammo.Logging (Pair, withThreadContext)
 import Control.Lens ((^.))
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson ((.=))
-import qualified Data.Aeson.Key as Key
+import Data.Aeson.Key qualified as Key
 import Freckle.App.Stats (HasStatsClient (..), tagsL)
-import qualified Freckle.App.Stats as Stats
+import Freckle.App.Stats qualified as Stats
 import Network.HTTP.Types.Status (Status (..))
 import Network.Wai (Middleware, Request, requestMethod, responseStatus)
 

--- a/package.yaml
+++ b/package.yaml
@@ -13,6 +13,8 @@ extra-doc-files:
 extra-source-files:
   - package.yaml
 
+language: GHC2021
+
 ghc-options:
   - -fignore-optim-changes
   - -fwrite-ide-info
@@ -37,30 +39,16 @@ dependencies:
   - base < 5
 
 default-extensions:
-  - BangPatterns
   - DataKinds
   - DeriveAnyClass
-  - DeriveFoldable
-  - DeriveFunctor
-  - DeriveGeneric
-  - DeriveLift
-  - DeriveTraversable
   - DerivingVia
   - DerivingStrategies
-  - FlexibleContexts
-  - FlexibleInstances
   - GADTs
-  - GeneralizedNewtypeDeriving
   - LambdaCase
-  - MultiParamTypeClasses
   - NoImplicitPrelude
   - NoMonomorphismRestriction
   - OverloadedStrings
-  - RankNTypes
   - RecordWildCards
-  - ScopedTypeVariables
-  - StandaloneDeriving
-  - TypeApplications
   - TypeFamilies
 
 library:

--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ when:
   - condition: "impl(ghc >= 9.8)"
     ghc-options:
       - -Wno-missing-role-annotations
+      - -Wno-missing-poly-kind-signatures
 
 dependencies:
   - base < 5

--- a/package.yaml
+++ b/package.yaml
@@ -20,6 +20,7 @@ ghc-options:
   - -Wno-all-missed-specialisations
   - -Wno-missing-exported-signatures # re-enables missing-signatures
   - -Wno-missing-import-lists
+  - -Wno-missing-kind-signatures
   - -Wno-missing-local-signatures
   - -Wno-missing-safe-haskell-mode
   - -Wno-monomorphism-restriction
@@ -31,9 +32,6 @@ when:
   - condition: "impl(ghc >= 9.8)"
     ghc-options:
       - -Wno-missing-role-annotations
-  - condition: "impl(ghc >= 9.2)"
-    ghc-options:
-      - -Wno-missing-kind-signatures
 
 dependencies:
   - base < 5

--- a/tests/Freckle/App/Bugsnag/MetaDataSpec.hs
+++ b/tests/Freckle/App/Bugsnag/MetaDataSpec.hs
@@ -10,7 +10,7 @@ import Data.Bugsnag
 import Freckle.App.Bugsnag
 import Freckle.App.Bugsnag.MetaData
 import Freckle.App.Stats
-import qualified Freckle.App.Stats as Stats
+import Freckle.App.Stats qualified as Stats
 
 spec :: Spec
 spec = do

--- a/tests/Freckle/App/CsvSpec.hs
+++ b/tests/Freckle/App/CsvSpec.hs
@@ -7,11 +7,11 @@ import Freckle.App.Prelude
 import Conduit (ConduitT, MonadThrow, ResourceT, yieldMany)
 import Control.Monad.Validate (Validate, refute, runValidate)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Csv hiding (header)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Sequence.NonEmpty (NESeq)
-import qualified Data.Vector as V
+import Data.Vector qualified as V
 import Data.Void (Void)
 import Freckle.App.Csv
 import Test.Hspec

--- a/tests/Freckle/App/Http/CacheSpec.hs
+++ b/tests/Freckle/App/Http/CacheSpec.hs
@@ -7,13 +7,13 @@ module Freckle.App.Http.CacheSpec
 
 import Freckle.App.Prelude
 
-import qualified Codec.Compression.GZip as GZip
+import Codec.Compression.GZip qualified as GZip
 import Control.Lens ((&), (.~), (<>~))
 import Control.Monad.State (StateT, execStateT)
 import Data.Aeson (FromJSON, eitherDecode)
 import Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.HashMap.Strict as HashMap
+import Data.ByteString.Lazy qualified as BSL
+import Data.HashMap.Strict qualified as HashMap
 import Data.Time (addUTCTime)
 import Freckle.App.Http
 import Freckle.App.Http.Cache

--- a/tests/Freckle/App/HttpSpec.hs
+++ b/tests/Freckle/App/HttpSpec.hs
@@ -7,7 +7,7 @@ import Freckle.App.Prelude
 import Control.Lens (to, (^?), _Left, _Right)
 import Data.Aeson
 import Data.Aeson.Lens
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Freckle.App.Http
 import Freckle.App.Test.Http
 import Network.HTTP.Types.Status (status200)

--- a/tests/Freckle/App/Memcached/ServersSpec.hs
+++ b/tests/Freckle/App/Memcached/ServersSpec.hs
@@ -6,7 +6,7 @@ import Freckle.App.Prelude
 
 import Control.Error.Util (hush)
 import Data.Either (isLeft, isRight)
-import qualified Database.Memcache.Client as Memcache
+import Database.Memcache.Client qualified as Memcache
 import Freckle.App.Memcached.Servers
 import Freckle.App.Test
 

--- a/tests/Freckle/App/MemcachedSpec.hs
+++ b/tests/Freckle/App/MemcachedSpec.hs
@@ -11,12 +11,12 @@ import Blammo.Logging.Logger
 import Control.Lens (lens, to, (^?))
 import Data.Aeson (Value (..))
 import Data.Aeson.Lens
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
-import qualified Freckle.App.Env as Env
+import Data.List.NonEmpty qualified as NE
+import Data.Text qualified as T
+import Freckle.App.Env qualified as Env
 import Freckle.App.Memcached
 import Freckle.App.Memcached.Client (MemcachedClient, withMemcachedClient)
-import qualified Freckle.App.Memcached.Client as Memcached
+import Freckle.App.Memcached.Client qualified as Memcached
 import Freckle.App.Memcached.Servers
 import Freckle.App.OpenTelemetry
 

--- a/tests/Freckle/App/OpenTelemetry/ContextSpec.hs
+++ b/tests/Freckle/App/OpenTelemetry/ContextSpec.hs
@@ -7,11 +7,11 @@ import Freckle.App.Test
 import Blammo.Logging
 import Blammo.Logging.Logger (newTestLogger)
 import Control.Lens (lens)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Freckle.App.OpenTelemetry
 import Freckle.App.OpenTelemetry.Context
 import Network.HTTP.Types.Header (Header)
-import qualified OpenTelemetry.Trace.Core as Trace
+import OpenTelemetry.Trace.Core qualified as Trace
 
 data App = App
   { appLogger :: Logger

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,7 +5,7 @@ module Main
 import Prelude
 
 import Freckle.App.Test.Hspec.Runner (runParConfig)
-import qualified Spec
+import Spec qualified
 import Test.Hspec
 
 main :: IO ()


### PR DESCRIPTION
- GHC2021
- fourmolu everything - Mostly changes imports to post-qualified - Also includes a few changes that fix style violations that fourmolu couldn't auto-update because of `CPP`.
- removed a >= ghc 9.2 conditional in the package definition that is irrelevant since 9.2 is the min bound