### PR TITLE
Add `httpBytes`

### DIFF
--- a/library/Freckle/App/Http.hs
+++ b/library/Freckle/App/Http.hs
@@ -14,6 +14,9 @@ module Freckle.App.Http
   , HttpDecodeError (..)
   , httpDecode
 
+    -- * Raw response
+  , httpBytes
+
     -- * Pagination
   , httpPaginated
   , sourcePaginated
@@ -199,6 +202,13 @@ httpDecode decode req = do
   resp <- httpLbs req
   let body = getResponseBody resp
   pure $ first (HttpDecodeError body) . decode <$> resp
+
+-- | Make a request without decoding the body
+httpBytes
+  :: MonadHttp m
+  => Request
+  -> m (Response ByteString)
+httpBytes = httpLbs
 
 -- | Request all pages of a paginated endpoint into some 'Monoid'
 --


### PR DESCRIPTION
See our monorepo, PR 34769 for a refactor that would have benefited from this.

We probably could just call `httpLbs` directly but I figured since this module is trying to centralize HTTP we'd want it re-exported here.