### PR TITLE
Add `Freckle.App.Http (setRequestMethod)`

### DIFF
--- a/library/Freckle/App/Http.hs
+++ b/library/Freckle/App/Http.hs
@@ -32,6 +32,7 @@ module Freckle.App.Http
   , setRequestBodyJSON
   , setRequestBodyURLEncoded
   , setRequestCheckStatus
+  , setRequestMethod
   , setRequestPath
   , disableRequestDecompress
 
@@ -71,6 +72,7 @@ module Freckle.App.Http
   , statusIsRedirection
   , statusIsClientError
   , statusIsServerError
+  , StdMethod (..)
   ) where
 
 import Freckle.App.Prelude
@@ -91,8 +93,9 @@ import Freckle.App.Http.Paginate
 import Freckle.App.Http.Retry
 import Network.HTTP.Client qualified as HTTP (Request (..))
 import Network.HTTP.Conduit (HttpExceptionContent (..))
-import Network.HTTP.Simple hiding (httpLbs, httpNoBody)
+import Network.HTTP.Simple hiding (httpLbs, httpNoBody, setRequestMethod)
 import Network.HTTP.Simple qualified as HTTP
+import Network.HTTP.Types (StdMethod (..), renderStdMethod)
 import Network.HTTP.Types.Header (hAccept, hAuthorization)
 import Network.HTTP.Types.Status
   ( Status
@@ -250,6 +253,9 @@ addAcceptHeader = addRequestHeader hAccept
 
 addBearerAuthorizationHeader :: BS.ByteString -> Request -> Request
 addBearerAuthorizationHeader = addRequestHeader hAuthorization . ("Bearer " <>)
+
+setRequestMethod :: StdMethod -> Request -> Request
+setRequestMethod method req = req {HTTP.method = renderStdMethod method}
 
 disableRequestDecompress :: Request -> Request
 disableRequestDecompress req =


### PR DESCRIPTION
**Why?**

As far as I know there are currently 2 ways to use a non-`GET` request method:
1. including method in the request string (e.g. `parseRequest_ $ "POST " <> url`)
2. importing lower-level HTTP module and setting the field directly (e.g. `req { HTTP.method = "POST"}`)

**2** breaks the centralization we're providing with this module by requiring consumers to import an internal thing.

Also both of these are stringly typed, producing a runtime error if a mistake is made, exs. forgotten space, or casing:

> Note that the request method must be provided as all capital letters.

^ from `http-conduit`'s docs.

**Note**

We could just re-export `Network.HTTP.Simple (setRequestMethod)`, however, it still has the stringly-typed problem (it takes a `ByteString`). `StdMethod` gives us nice type-safety and covers all our current (and I'd bet future) use-cases.