### PR TITLE
runDB: add otel span for holding a database connection

### DIFF
--- a/freckle-app/CHANGELOG.md
+++ b/freckle-app/CHANGELOG.md
@@ -1,4 +1,16 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.2.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.2.1...main)
+
+## [v1.20.2.1](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.2.0...freckle-app-v1.20.2.1)
+
+Adds an OpenTelemetry span called "runSqlPool" within each "runDB" span.
+
+- `runDB` covers the entire action, from the time it requests a connection
+  from the pool to the time it returns the connection to the pool.
+- The new `runSqlPool` span covers the actions taken while _holding_ a
+  connection. This span doesn't start until a connection is obtained.
+
+This makes the trace more explicitly reflect situations where a thread was
+blocked by an exhausted connection pool.
 
 ## [v1.20.2.0](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.1.2...freckle-app-v1.20.2.0)
 

--- a/freckle-app/freckle-app.cabal
+++ b/freckle-app/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.22
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.20.2.0
+version:        1.20.2.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app/library/Freckle/App/Database.hs
+++ b/freckle-app/library/Freckle/App/Database.hs
@@ -176,7 +176,7 @@ runDB action = do
   Stats.withGauge Stats.dbEnqueuedAndProcessing $
     inSpan "runDB" (clientSpanArguments {Trace.attributes = dbAttributes}) $
       runSqlPoolWithExtensibleHooks
-        (inSpan "with DB connection" defaultSpanArguments action)
+        (inSpan "runSqlPool" defaultSpanArguments action)
         pool
         Nothing
         hooks'

--- a/freckle-app/library/Freckle/App/Database.hs
+++ b/freckle-app/library/Freckle/App/Database.hs
@@ -175,7 +175,11 @@ runDB action = do
         }
   Stats.withGauge Stats.dbEnqueuedAndProcessing $
     inSpan "runDB" (clientSpanArguments {Trace.attributes = dbAttributes}) $
-      runSqlPoolWithExtensibleHooks action pool Nothing hooks'
+      runSqlPoolWithExtensibleHooks
+        (inSpan "with DB connection" defaultSpanArguments action)
+        pool
+        Nothing
+        hooks'
  where
   dbAttributes = HashMap.fromList [("service.name", "database")]
 

--- a/freckle-app/package.yaml
+++ b/freckle-app/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.20.2.0
+version: 1.20.2.1
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
Curious what y'all think of this idea - I'd like our traces to more explicitly show within `runDB` spans how much time is spent

- waiting on the connection pool; versus
- actually holding a connection.

The nicest way to display this would be to have a "waiting on the connection pool" span, but since the pool acquire is done by `persistent`, that doesn't seem super easy. Putting a span around the action, though, is trivial.

- Pro: When the reason for an action being slow was a long wait on the connection pool, that will appear clearly in its trace.
- Con: Maybe clutters up the traces a bit, since it adds a level of depth under every `runDB` which won't be super informative under normal performance.