### PR TITLE
always upload haddocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
       - run: sudo apt-get install --assume-yes --no-install-recommends librdkafka-dev
 
       - name: "Build with Haddocks"
-        if: ${{ matrix.package == 'freckle-kafka' }}
         uses: freckle/stack-action@v5
         with:
           test: false
@@ -65,5 +64,4 @@ jobs:
         run: stack --stack-yaml stack-lts-20.26.yaml upload --pvp-bounds lower ${{ matrix.package }}
 
       - name: "Upload documentation"
-        if: ${{ matrix.package == 'freckle-kafka' }}
         run: stack upload --documentation ${{ matrix.package }}


### PR DESCRIPTION
We're not getting `freckle-app` haddocks on Hackage because the libpq dependency is making it fail to compile. If #159 really is fixed then I don't see the harm in just always uploading the docs.