### PR TITLE
improve getJsonBody error output

### DIFF
--- a/freckle-app/CHANGELOG.md
+++ b/freckle-app/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.1.1...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.1.2...main)
+
+## [v1.20.1.1](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.1.1...freckle-app-v1.20.1.2)
+
+Improve quality of error message output from `getJsonBody` and `getCsvBody`
+in `Freckle.App.Test.Yesod`.
 
 ## [v1.20.1.1](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.1.0...freckle-app-v1.20.1.1)
 

--- a/freckle-app/freckle-app.cabal
+++ b/freckle-app/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.22
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.20.1.1
+version:        1.20.1.2
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app/package.yaml
+++ b/freckle-app/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.20.1.1
+version: 1.20.1.2
 maintainer: Freckle Education
 category: Utils
 github: freckle/freckle-app


### PR DESCRIPTION
`getJsonBody` now just passes through to yesod-test, and `getCsvBody` is a copy of what that does.

I'm being lazy and skipping over the CSV content type check right now because I don't immediately know what the MIME type is or if we always set it correctly in our app.