### PR TITLE
fix version of persistent-sql-lifted

### DIFF
--- a/persistent-sql-lifted/LICENSE
+++ b/persistent-sql-lifted/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023-2024 Renaissance Learning Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/persistent-sql-lifted/package.yaml
+++ b/persistent-sql-lifted/package.yaml
@@ -1,5 +1,5 @@
 name: persistent-sql-lifted
-version: 1.20.3.0
+version: 0.0.0.0
 
 maintainer: Freckle Education
 category: Database

--- a/persistent-sql-lifted/persistent-sql-lifted.cabal
+++ b/persistent-sql-lifted/persistent-sql-lifted.cabal
@@ -12,6 +12,8 @@ category:       Database
 homepage:       https://github.com/freckle/freckle-app#readme
 bug-reports:    https://github.com/freckle/freckle-app/issues
 maintainer:     Freckle Education
+license:        MIT
+license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     package.yaml

--- a/persistent-sql-lifted/persistent-sql-lifted.cabal
+++ b/persistent-sql-lifted/persistent-sql-lifted.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           persistent-sql-lifted
-version:        1.20.3.0
+version:        0.0.0.0
 synopsis:       ...
 description:    Please see README.md
 category:       Database


### PR DESCRIPTION
Accidentally copied the version number from freckle-app instead of starting from zero. It accidentally didn't release anyway, so may as well fix it.

... also forgot to add the license.