### PR TITLE
Add kafka batch consumer

### DIFF
--- a/freckle-app/CHANGELOG.md
+++ b/freckle-app/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.21.0.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.21.1.0...main)
+
+## [v1.21.1.0](https://github.com/freckle/freckle-app/compare/freckle-app-v1.21.0.0...freckle-app-v1.21.1.0)
+
+Add `Freckle.App.Kafka.Consumer.runConsumerBatched`
 
 ## [v1.21.0.0](https://github.com/freckle/freckle-app/compare/freckle-app-v1.20.3.0...freckle-app-v1.21.0.0)
 

--- a/freckle-kafka/freckle-kafka.cabal
+++ b/freckle-kafka/freckle-kafka.cabal
@@ -61,7 +61,6 @@ library
     , resource-pool >=0.4.0.0
     , text
     , time
-    , transformers
     , unliftio
     , unordered-containers
     , yesod-core

--- a/freckle-kafka/freckle-kafka.cabal
+++ b/freckle-kafka/freckle-kafka.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -61,6 +61,7 @@ library
     , resource-pool >=0.4.0.0
     , text
     , time
+    , transformers
     , unliftio
     , unordered-containers
     , yesod-core

--- a/freckle-kafka/package.yaml
+++ b/freckle-kafka/package.yaml
@@ -67,6 +67,7 @@ library:
     - resource-pool >= 0.4.0.0
     - text
     - time
+    - transformers
     - unliftio
     - unordered-containers
     - yesod-core

--- a/freckle-kafka/package.yaml
+++ b/freckle-kafka/package.yaml
@@ -67,7 +67,6 @@ library:
     - resource-pool >= 0.4.0.0
     - text
     - time
-    - transformers
     - unliftio
     - unordered-containers
     - yesod-core


### PR DESCRIPTION
Adds a new `runConsumerBatched` so that we can start playing with batched kafka consumers to see if it can help throughput.