### PR TITLE
Add pooled varieties to Freckle.App.Async

### DIFF
--- a/freckle-app/CHANGELOG.md
+++ b/freckle-app/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.23.0.1...main)
 
+## [v1.23.1.0](https://github.com/freckle/freckle-app/compare/freckle-app-v1.23.0.1...freckle-app-v1.23.1.0)
+
+- Add `pooledMapConcurrently` et-al to `Freckle.App.Async`
+
 ## [v1.23.0.1](https://github.com/freckle/freckle-app/compare/freckle-app-v1.23.0.0...freckle-app-v1.23.0.1)
 
 Add more thread context preserving combinators to `Freckle.App.Async`

--- a/freckle-app/freckle-app.cabal
+++ b/freckle-app/freckle-app.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.23.0.0
+version:        1.23.0.1
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app/freckle-app.cabal
+++ b/freckle-app/freckle-app.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.22
 -- see: https://github.com/sol/hpack
 
 name:           freckle-app
-version:        1.23.0.1
+version:        1.23.1.0
 synopsis:       Haskell application toolkit used at Freckle
 description:    Please see README.md
 category:       Utils

--- a/freckle-app/library/Freckle/App/Async.hs
+++ b/freckle-app/library/Freckle/App/Async.hs
@@ -6,6 +6,14 @@ module Freckle.App.Async
 
     -- * "UnliftIO.Async" functions that preserve context
   , async
+  , pooledMapConcurrentlyN
+  , pooledMapConcurrently
+  , pooledMapConcurrentlyN_
+  , pooledMapConcurrently_
+  , pooledForConcurrentlyN
+  , pooledForConcurrently
+  , pooledForConcurrentlyN_
+  , pooledForConcurrently_
   , mapConcurrently
   , forConcurrently
   , mapConcurrently_
@@ -42,6 +50,58 @@ async :: (MonadMask m, MonadUnliftIO m) => m a -> m (Async a)
 async f = do
   context <- getThreadContext
   UnliftIO.async $ withThreadContext context f
+
+-- | 'UnliftIO.Async.pooledMapConcurrently' but passing the thread context along
+pooledMapConcurrentlyN
+  :: (MonadUnliftIO m, MonadMask m, Traversable t)
+  => Int -> (a -> m b) -> t a -> m (t b)
+pooledMapConcurrentlyN n f xs = do
+  context <- getThreadContext
+  UnliftIO.pooledMapConcurrentlyN n (withThreadContext context . f) xs
+
+-- | 'UnliftIO.Async.pooledMapConcurrently' but passing the thread context along
+pooledMapConcurrently
+  :: (MonadUnliftIO m, MonadMask m, Traversable t) => (a -> m b) -> t a -> m (t b)
+pooledMapConcurrently f xs = do
+  context <- getThreadContext
+  UnliftIO.pooledMapConcurrently (withThreadContext context . f) xs
+
+-- | 'UnliftIO.Async.pooledMapConcurrently' but passing the thread context along
+pooledMapConcurrentlyN_
+  :: (MonadUnliftIO m, MonadMask m, Traversable t)
+  => Int -> (a -> m b) -> t a -> m ()
+pooledMapConcurrentlyN_ n f xs = do
+  context <- getThreadContext
+  UnliftIO.pooledMapConcurrentlyN_ n (withThreadContext context . f) xs
+
+-- | 'UnliftIO.Async.pooledMapConcurrently' but passing the thread context along
+pooledMapConcurrently_
+  :: (MonadUnliftIO m, MonadMask m, Traversable t) => (a -> m b) -> t a -> m ()
+pooledMapConcurrently_ f xs = do
+  context <- getThreadContext
+  UnliftIO.pooledMapConcurrently_ (withThreadContext context . f) xs
+
+-- | 'UnliftIO.Async.pooledForConcurrently' but passing the thread context along
+pooledForConcurrentlyN
+  :: (MonadUnliftIO m, MonadMask m, Traversable t)
+  => Int -> t a -> (a -> m b) -> m (t b)
+pooledForConcurrentlyN n = flip $ pooledMapConcurrentlyN n
+
+-- | 'UnliftIO.Async.pooledForConcurrently' but passing the thread context along
+pooledForConcurrently
+  :: (MonadUnliftIO m, MonadMask m, Traversable t) => t a -> (a -> m b) -> m (t b)
+pooledForConcurrently = flip pooledMapConcurrently
+
+-- | 'UnliftIO.Async.pooledForConcurrently' but passing the thread context along
+pooledForConcurrentlyN_
+  :: (MonadUnliftIO m, MonadMask m, Traversable t)
+  => Int -> t a -> (a -> m b) -> m ()
+pooledForConcurrentlyN_ n = flip $ pooledMapConcurrentlyN_ n
+
+-- | 'UnliftIO.Async.pooledForConcurrently' but passing the thread context along
+pooledForConcurrently_
+  :: (MonadUnliftIO m, MonadMask m, Traversable t) => t a -> (a -> m b) -> m ()
+pooledForConcurrently_ = flip pooledMapConcurrently_
 
 -- | 'UnliftIO.Async.mapConcurrently' but passing the thread context along
 mapConcurrently

--- a/freckle-app/library/Freckle/App/Async.hs
+++ b/freckle-app/library/Freckle/App/Async.hs
@@ -127,7 +127,7 @@ forConcurrently_
   :: (MonadUnliftIO m, MonadMask m, Traversable t) => t a -> (a -> m b) -> m ()
 forConcurrently_ = flip mapConcurrently_
 
--- | Run a list of actions concurrently
+-- | Run a list of actions concurrently, combining the results monoidally
 --
 -- The forked threads will have the current thread context copied to them.
 foldConcurrently

--- a/freckle-app/library/Freckle/App/Async.hs
+++ b/freckle-app/library/Freckle/App/Async.hs
@@ -51,7 +51,7 @@ async f = do
   context <- getThreadContext
   UnliftIO.async $ withThreadContext context f
 
--- | 'UnliftIO.Async.pooledMapConcurrently' but passing the thread context along
+-- | 'UnliftIO.Async.pooledMapConcurrentlyN' but passing the thread context along
 pooledMapConcurrentlyN
   :: (MonadUnliftIO m, MonadMask m, Traversable t)
   => Int -> (a -> m b) -> t a -> m (t b)
@@ -66,7 +66,7 @@ pooledMapConcurrently f xs = do
   context <- getThreadContext
   UnliftIO.pooledMapConcurrently (withThreadContext context . f) xs
 
--- | 'UnliftIO.Async.pooledMapConcurrently' but passing the thread context along
+-- | 'UnliftIO.Async.pooledMapConcurrentlyN_' but passing the thread context along
 pooledMapConcurrentlyN_
   :: (MonadUnliftIO m, MonadMask m, Traversable t)
   => Int -> (a -> m b) -> t a -> m ()
@@ -74,14 +74,14 @@ pooledMapConcurrentlyN_ n f xs = do
   context <- getThreadContext
   UnliftIO.pooledMapConcurrentlyN_ n (withThreadContext context . f) xs
 
--- | 'UnliftIO.Async.pooledMapConcurrently' but passing the thread context along
+-- | 'UnliftIO.Async.pooledMapConcurrently_' but passing the thread context along
 pooledMapConcurrently_
   :: (MonadUnliftIO m, MonadMask m, Traversable t) => (a -> m b) -> t a -> m ()
 pooledMapConcurrently_ f xs = do
   context <- getThreadContext
   UnliftIO.pooledMapConcurrently_ (withThreadContext context . f) xs
 
--- | 'UnliftIO.Async.pooledForConcurrently' but passing the thread context along
+-- | 'UnliftIO.Async.pooledForConcurrentlyN' but passing the thread context along
 pooledForConcurrentlyN
   :: (MonadUnliftIO m, MonadMask m, Traversable t)
   => Int -> t a -> (a -> m b) -> m (t b)
@@ -92,13 +92,13 @@ pooledForConcurrently
   :: (MonadUnliftIO m, MonadMask m, Traversable t) => t a -> (a -> m b) -> m (t b)
 pooledForConcurrently = flip pooledMapConcurrently
 
--- | 'UnliftIO.Async.pooledForConcurrently' but passing the thread context along
+-- | 'UnliftIO.Async.pooledForConcurrentlyN_' but passing the thread context along
 pooledForConcurrentlyN_
   :: (MonadUnliftIO m, MonadMask m, Traversable t)
   => Int -> t a -> (a -> m b) -> m ()
 pooledForConcurrentlyN_ n = flip $ pooledMapConcurrentlyN_ n
 
--- | 'UnliftIO.Async.pooledForConcurrently' but passing the thread context along
+-- | 'UnliftIO.Async.pooledForConcurrently_' but passing the thread context along
 pooledForConcurrently_
   :: (MonadUnliftIO m, MonadMask m, Traversable t) => t a -> (a -> m b) -> m ()
 pooledForConcurrently_ = flip pooledMapConcurrently_

--- a/freckle-app/library/Freckle/App/Async.hs
+++ b/freckle-app/library/Freckle/App/Async.hs
@@ -22,10 +22,8 @@ module Freckle.App.Async
     -- ** Related extensions
   , foldConcurrently
 
-    -- * "Control.Immortal" functions that preserve context
+    -- * "Control.Immortal"-related functions
   , immortalCreate
-
-    -- ** Related extensions
   , immortalCreateLogged
   ) where
 

--- a/freckle-app/package.yaml
+++ b/freckle-app/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.23.0.1
+version: 1.23.1.0
 
 maintainer: Freckle Education
 category: Utils


### PR DESCRIPTION
### [Re-organize Freckle.App.Async module](https://github.com/freckle/freckle-app/pull/237/commits/d662ed62ae8a1dfacaa6d83cca73e3d08719e55a)
[d662ed6](https://github.com/freckle/freckle-app/pull/237/commits/d662ed62ae8a1dfacaa6d83cca73e3d08719e55a)

* Add some section headings
* Put functions we're overriding in the same order as their upstream

### [Add pooled varieties to Freckle.App.Async](https://github.com/freckle/freckle-app/pull/237/commits/32a81a4d5032cf16e12c91cc31f894e71201b6a4)
[32a81a4](https://github.com/freckle/freckle-app/pull/237/commits/32a81a4d5032cf16e12c91cc31f894e71201b6a4)

### [Version bump](https://github.com/freckle/freckle-app/pull/237/commits/303a77b7575e113f2bb4c7eaa71bec77235f6fcf)
[303a77b](https://github.com/freckle/freckle-app/pull/237/commits/303a77b7575e113f2bb4c7eaa71bec77235f6fcf)