### PR TITLE
fix(freckle-http): use TTL in set operation

### DIFF
--- a/freckle-app/CHANGELOG.md
+++ b/freckle-app/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.23.3.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-app-v1.24.0.0...main)
+
+## [v1.24.0.0](https://github.com/freckle/freckle-app/compare/freckle-app-v1.23.3.0...freckle-app-v1.24.0.0)
+
+- Update `HttpCache.set` to accept TTL (and use it in memcached implementation)
 
 ## [v1.23.3.0](https://github.com/freckle/freckle-app/compare/freckle-app-v1.23.2.0...freckle-app-v1.23.3.0)
 

--- a/freckle-app/package.yaml
+++ b/freckle-app/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-app
-version: 1.23.3.0
+version: 1.24.0.0
 
 maintainer: Freckle Education
 category: Utils

--- a/freckle-http/library/Freckle/App/Http/Cache.hs
+++ b/freckle-http/library/Freckle/App/Http/Cache.hs
@@ -68,7 +68,7 @@ data HttpCacheCodec t = HttpCacheCodec
 
 data HttpCache m t = HttpCache
   { get :: CacheKey -> m (Either SomeException (Maybe t))
-  , set :: CacheKey -> t -> m (Either SomeException ())
+  , set :: CacheKey -> t -> CacheTTL -> m (Either SomeException ())
   , evict :: CacheKey -> m (Either SomeException ())
   }
 
@@ -176,7 +176,7 @@ httpCached settings doHttp req =
              , "ttl" .= fromCacheTTL ttl
              ]
       let cresp = CachedResponse {response = resp, inserted = now, ttl = ttl}
-      fromEx () $ settings.cache.set key $ settings.codec.serialise cresp
+      fromEx () $ settings.cache.set key (settings.codec.serialise cresp) ttl
 
     gunzipResponseBody req resp
 

--- a/freckle-http/library/Freckle/App/Http/Cache/Memcached.hs
+++ b/freckle-http/library/Freckle/App/Http/Cache/Memcached.hs
@@ -74,7 +74,7 @@ memcachedHttpCache
 memcachedHttpCache =
   HttpCache
     { get = try . Memcached.get
-    , set = \k v -> try $ Memcached.set k v 0
+    , set = \k v t -> try $ Memcached.set k v t
     , evict = try . Memcached.delete
     }
 

--- a/freckle-http/library/Freckle/App/Http/Cache/State.hs
+++ b/freckle-http/library/Freckle/App/Http/Cache/State.hs
@@ -75,7 +75,7 @@ stateHttpCache
 stateHttpCache =
   HttpCache
     { get = \key -> fmap Right $ use $ cacheL . mapL . at key
-    , set = \key resp -> fmap Right $ cacheL . mapL . at key ?= resp
+    , set = \key resp _ -> fmap Right $ cacheL . mapL . at key ?= resp
     , evict = \key -> fmap Right $ cacheL . mapL . at key .= Nothing
     }
 


### PR DESCRIPTION
The backend-agnostic cache logic encodes TTL into the cached data,
checks it on read, and ignores/deletes it if expired.

For a backend that supports expiry itself (e.g. memcached), this should
not be necessary. And, at times of heavy load, the extra `delete`
operations can cause performance problems.

To address this, we update the `set` member of `HttpCache` to accept the
TTL value too. Then, in the memcached implementation, we use it to set
with the key that TTL, meaning expired values will simply not be
retrieved by `get` at all, and no `delete`s will occur (modulo races).

We do still retain the backend-agnostic logic, since the state
implementation (for example) does not support expiring keys and so
expiration still needs to be checked externally for such backends.

Since the signature of `HttpCache.set` is changing, this must be a major
version bump, even though it is unlikely to disrupt any users in
practice.
