### PR TITLE
add Natural to prelude

### DIFF
--- a/freckle-app/library/Freckle/App/Random.hs
+++ b/freckle-app/library/Freckle/App/Random.hs
@@ -14,7 +14,6 @@ import Control.Monad.ST (runST)
 import Control.Monad.State.Strict (execStateT, get, put)
 import Data.Functor ((<&>))
 import Data.STRef (newSTRef, readSTRef, writeSTRef)
-import Numeric.Natural (Natural)
 
 import Data.Set qualified as Set
 

--- a/freckle-prelude/CHANGELOG.md
+++ b/freckle-prelude/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-prelude-v0.0.3.0...main)
+## [_Unreleased_](https://github.com/freckle/freckle-app/compare/freckle-prelude-v0.0.4.0...main)
+
+## [v0.0.4.0](https://github.com/freckle/freckle-app/compare/freckle-prelude-v0.0.3.0...freckle-prelude-v0.0.4.0)
+
+Add `Natural` from `Numeric.Natural` in `base`.
 
 ## [v0.0.3.0](https://github.com/freckle/freckle-app/compare/freckle-prelude-v0.0.2.0...freckle-prelude-v0.0.3.0)
 

--- a/freckle-prelude/freckle-prelude.cabal
+++ b/freckle-prelude/freckle-prelude.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           freckle-prelude
-version:        0.0.3.0
+version:        0.0.4.0
 synopsis:       Standard prelude for Freckle applications
 description:    Please see README.md
 category:       Prelude

--- a/freckle-prelude/library/Freckle/App/Prelude.hs
+++ b/freckle-prelude/library/Freckle/App/Prelude.hs
@@ -16,6 +16,7 @@ module Freckle.App.Prelude
   , MonadIO
   , MonadReader
   , MonadUnliftIO
+  , Natural
   , NominalDiffTime
   , NonEmpty
   , PrimMonad
@@ -147,6 +148,7 @@ import Data.Vector (Vector)
 import Data.Void (Void)
 import Freckle.App.Exception
 import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
 
 -- Safe alternatives to prelude functions
 

--- a/freckle-prelude/package.yaml
+++ b/freckle-prelude/package.yaml
@@ -1,5 +1,5 @@
 name: freckle-prelude
-version: 0.0.3.0
+version: 0.0.4.0
 maintainer: Freckle Education
 category: Prelude
 github: freckle/freckle-app


### PR DESCRIPTION
`Natural` is pretty commonly used. I'm not aware of any name that conflicts with it. It's sort of a central part of the language since it's used [as a kind at the type level](https://hackage.haskell.org/package/base-4.21.0.0/docs/GHC-TypeLits.html).